### PR TITLE
Feat/password-recovery: adding password recovery user flow

### DIFF
--- a/src/actions/auth/send-email-with-link.ts
+++ b/src/actions/auth/send-email-with-link.ts
@@ -1,4 +1,3 @@
-import { emailTemplate } from '@/lib/constants'
 import { type User } from '@prisma/client'
 import jwt from 'jsonwebtoken'
 import { Resend } from 'resend'
@@ -14,16 +13,22 @@ const generateToken = (user: User) => {
   )
 }
 
+type EmailTemplateFunction = (user: User, url: string) => string
+
 const resend = new Resend(process.env.RESEND_API_KEY)
 
-export const sendEmailWithLink = async (user: User) => {
+export const sendEmailWithLink = async (
+  user: User,
+  template: EmailTemplateFunction,
+  subject: string
+) => {
   const token = generateToken(user)
   const url =
     process.env.NODE_ENV === 'development'
       ? `${process.env.BASE_URL_DEVELOPMENT}/set-password/${token}`
       : `${process.env.BASE_URL_PRODUCTION}/set-password/${token}`
 
-  const htmlTemplate = emailTemplate(user, url)
+  const htmlTemplate = template(user, url)
   const userEmail =
     process.env.NODE_ENV === 'development'
       ? process.env.DEVELOPER_EMAIL
@@ -37,7 +42,7 @@ export const sendEmailWithLink = async (user: User) => {
   await resend.emails.send({
     from: fromEmail,
     to: userEmail ?? user.email,
-    subject: 'Atualize sua senha - Borderless Coding Community',
+    subject,
     html: htmlTemplate
   })
 }

--- a/src/app/(auth)/(routes)/sign-in/[[...sign-in]]/components/main-form/index.tsx
+++ b/src/app/(auth)/(routes)/sign-in/[[...sign-in]]/components/main-form/index.tsx
@@ -1,0 +1,20 @@
+'use client'
+import useMainForm from './use-main-form'
+
+interface MainFormProps {
+  redirectUrl: string
+}
+
+const MainForm = ({ redirectUrl }: MainFormProps) => {
+  const { activeStep, formSteps } = useMainForm({
+    redirectUrl
+  })
+
+  return (
+    <div className="flex flex-col space-y-4 text-center my-auto">
+      {formSteps[activeStep]}
+    </div>
+  )
+}
+
+export default MainForm

--- a/src/app/(auth)/(routes)/sign-in/[[...sign-in]]/components/main-form/use-main-form.tsx
+++ b/src/app/(auth)/(routes)/sign-in/[[...sign-in]]/components/main-form/use-main-form.tsx
@@ -1,0 +1,33 @@
+import { useMemo, useState } from 'react'
+import PasswordRecoveryForm from '../password-recovery-form'
+import UserAuthForm from '../user-auth-form'
+
+interface UseMainFormProps {
+  redirectUrl: string
+}
+
+const useMainForm = ({ redirectUrl }: UseMainFormProps) => {
+  const [activeStep, setActiveStep] = useState(0)
+  const formSteps = useMemo(
+    () => [
+      <UserAuthForm
+        key="user-auth"
+        setActiveStep={setActiveStep}
+        redirectUrl={redirectUrl}
+      />,
+      <PasswordRecoveryForm
+        key="password-recovery"
+        setActiveStep={setActiveStep}
+      />
+    ],
+    [redirectUrl]
+  )
+
+  return {
+    activeStep,
+    setActiveStep,
+    formSteps
+  }
+}
+
+export default useMainForm

--- a/src/app/(auth)/(routes)/sign-in/[[...sign-in]]/components/password-recovery-form/index.tsx
+++ b/src/app/(auth)/(routes)/sign-in/[[...sign-in]]/components/password-recovery-form/index.tsx
@@ -1,0 +1,99 @@
+'use client'
+import { Icons } from '@/components/icons'
+import { Button } from '@/components/ui/button'
+import { Form, FormControl, FormField, FormItem } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { type Dispatch, type SetStateAction } from 'react'
+import { usePasswordRecoveryForm } from './use-password-recovery-form'
+
+interface PasswordRecoveryFormProps {
+  setActiveStep: Dispatch<SetStateAction<number>>
+}
+
+const PasswordRecoveryForm = ({ setActiveStep }: PasswordRecoveryFormProps) => {
+  const { form, onSubmit, isPending, isSuccess, status } =
+    usePasswordRecoveryForm({ setActiveStep })
+
+  const buttonStates = {
+    idle: {
+      text: 'Recover password',
+      icon: <Icons.lock className="w-4 h-4" />
+    },
+    pending: {
+      text: 'Recovering password',
+      icon: <Icons.loader className="h-4 w-4 mr-2 animate-spin" />
+    },
+    success: {
+      text: 'Password recovery email sent',
+      icon: <Icons.check className="w-4 h-4" />
+    },
+    error: {
+      text: 'Error recovering password',
+      icon: <Icons.close className="w-4 h-4" />
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="link"
+        size="sm"
+        onClick={() => {
+          setActiveStep(0)
+        }}
+        className="self-start"
+      >
+        <Icons.arrowBack className="h-4 w-4" /> Return
+      </Button>
+
+      <h1 className="text-2xl font-semibold tracking-tight">
+        Recover your password
+      </h1>
+
+      <p className="text-muted-foreground text-xs text-center max-w-[80%] self-center">
+        Enter your email address and we will send you a link to reset your
+        password.
+      </p>
+
+      <Form {...form}>
+        <form className="flex flex-col" onSubmit={form.handleSubmit(onSubmit)}>
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <Label className="sr-only" htmlFor="email">
+                  Email
+                </Label>
+                <FormControl>
+                  <Input
+                    {...field}
+                    id="email"
+                    placeholder="name@example.com"
+                    type="email"
+                    autoCapitalize="none"
+                    autoComplete="email"
+                    autoCorrect="off"
+                    disabled={isPending || isSuccess}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <Button
+            type="submit"
+            disabled={isPending || !form.formState.isValid}
+            data-success={isSuccess}
+            className="mt-6 gap-1 data-[success=true]:bg-green-500 data-[success=true]:text-white transition-colors"
+          >
+            {buttonStates[status].icon}
+            {buttonStates[status].text}
+          </Button>
+        </form>
+      </Form>
+    </>
+  )
+}
+
+export default PasswordRecoveryForm

--- a/src/app/(auth)/(routes)/sign-in/[[...sign-in]]/components/password-recovery-form/use-password-recovery-form.ts
+++ b/src/app/(auth)/(routes)/sign-in/[[...sign-in]]/components/password-recovery-form/use-password-recovery-form.ts
@@ -1,0 +1,68 @@
+import { toast } from '@/components/ui/use-toast'
+import { api } from '@/lib/api'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation } from '@tanstack/react-query'
+import { type Dispatch, type SetStateAction } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+const passwordRecoverySchema = z.object({
+  email: z.string().email()
+})
+
+interface UsePasswordRecoveryFormProps {
+  setActiveStep: Dispatch<SetStateAction<number>>
+}
+
+export const usePasswordRecoveryForm = ({
+  setActiveStep
+}: UsePasswordRecoveryFormProps) => {
+  const form = useForm({
+    resolver: zodResolver(passwordRecoverySchema),
+    mode: 'onChange',
+    defaultValues: {
+      email: ''
+    }
+  })
+
+  const { mutateAsync, isPending, isSuccess, status, reset } = useMutation({
+    mutationKey: ['password-recovery'],
+    mutationFn: async ({ email }: { email: string }) => {
+      const response = await api.post('/api/password-recovery', { email })
+      return response
+    },
+    onSuccess: async () => {
+      toast({
+        title: 'Your password recovery email has been sent!',
+        description: 'Check your inbox for further instructions'
+      })
+      setTimeout(() => {
+        reset()
+        setActiveStep(0)
+      }, 2000)
+    },
+    onError: async error => {
+      console.log(JSON.stringify(error, null, 2))
+      toast({
+        title: 'An error ocurred while sending the recovery email',
+        description: 'Try again later',
+        variant: 'destructive'
+      })
+      setTimeout(() => {
+        reset()
+      }, 3000)
+    }
+  })
+
+  async function onSubmit(values: z.infer<typeof passwordRecoverySchema>) {
+    await mutateAsync(values)
+    form.reset()
+  }
+  return {
+    form,
+    onSubmit,
+    isPending,
+    isSuccess,
+    status
+  }
+}

--- a/src/app/(auth)/(routes)/sign-in/[[...sign-in]]/components/user-auth-form/index.tsx
+++ b/src/app/(auth)/(routes)/sign-in/[[...sign-in]]/components/user-auth-form/index.tsx
@@ -4,9 +4,15 @@ import { Button } from '@/components/ui/button'
 import { Form, FormControl, FormField, FormItem } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { type Dispatch, type SetStateAction } from 'react'
 import { useUserAuthForm } from './use-user-auth-form'
 
-const UserAuthForm = ({ redirectUrl }: { redirectUrl: string }) => {
+interface UserAuthFormProps {
+  redirectUrl: string
+  setActiveStep: Dispatch<SetStateAction<number>>
+}
+
+const UserAuthForm = ({ redirectUrl, setActiveStep }: UserAuthFormProps) => {
   const {
     form,
     onSubmit,
@@ -19,84 +25,107 @@ const UserAuthForm = ({ redirectUrl }: { redirectUrl: string }) => {
   })
 
   return (
-    <Form {...form}>
-      <form className="flex flex-col" onSubmit={form.handleSubmit(onSubmit)}>
-        <FormField
-          control={form.control}
-          name="email"
-          render={({ field }) => (
-            <FormItem>
-              <Label className="sr-only" htmlFor="email">
-                Email
-              </Label>
-              <FormControl>
-                <Input
-                  {...field}
-                  id="email"
-                  placeholder="name@example.com"
-                  type="email"
-                  autoCapitalize="none"
-                  autoComplete="email"
-                  autoCorrect="off"
-                  disabled={isPending}
-                />
-              </FormControl>
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="password"
-          render={({ field }) => (
-            <FormItem>
-              <Label className="sr-only" htmlFor="password">
-                Password
-              </Label>
-              <FormControl>
-                <Input
-                  {...field}
-                  id="password"
-                  placeholder="********"
-                  type={showPassword ? 'text' : 'password'}
-                  disabled={isPending}
-                  icon={
-                    showPassword ? (
-                      <Icons.eyeOff
-                        className="h-4 w-4 cursor-pointer"
-                        onClick={toggleShowPassword}
-                      />
-                    ) : (
-                      <Icons.eye
-                        className="h-4 w-4 cursor-pointer"
-                        onClick={toggleShowPassword}
-                      />
-                    )
-                  }
-                />
-              </FormControl>
-            </FormItem>
-          )}
-        />
-        <Button
-          type="submit"
-          disabled={isPending || !form.formState.isValid}
-          data-signedin={isSuccess}
-          className="mt-4 gap-1 data-[signedin=true]:bg-green-500 data-[signedin=true]:text-white transition-colors"
-        >
-          {isPending ? (
-            <>
-              <Icons.loader className="h-4 w-4 mr-2 animate-spin" /> Signing In
-            </>
-          ) : isSuccess ? (
-            <>
-              <Icons.check className="w-4 h-4" /> Redirecting...
-            </>
-          ) : (
-            <>Sign In</>
-          )}
-        </Button>
-      </form>
-    </Form>
+    <>
+      <h1 className="text-2xl font-semibold tracking-tight">
+        Login to community
+      </h1>
+      <p className="text-sm text-muted-foreground">
+        Enter your credentials to access your account
+      </p>
+      <Form {...form}>
+        <form className="flex flex-col" onSubmit={form.handleSubmit(onSubmit)}>
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <Label className="sr-only" htmlFor="email">
+                  Email
+                </Label>
+                <FormControl>
+                  <Input
+                    {...field}
+                    id="email"
+                    placeholder="name@example.com"
+                    type="email"
+                    autoCapitalize="none"
+                    autoComplete="email"
+                    autoCorrect="off"
+                    disabled={isPending}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <Label className="sr-only" htmlFor="password">
+                  Password
+                </Label>
+                <FormControl>
+                  <div className="flex flex-col items-end gap-1">
+                    <Input
+                      {...field}
+                      id="password"
+                      placeholder="********"
+                      type={showPassword ? 'text' : 'password'}
+                      disabled={isPending}
+                      icon={
+                        showPassword ? (
+                          <Icons.eyeOff
+                            className="h-4 w-4 cursor-pointer"
+                            onClick={toggleShowPassword}
+                          />
+                        ) : (
+                          <Icons.eye
+                            className="h-4 w-4 cursor-pointer"
+                            onClick={toggleShowPassword}
+                          />
+                        )
+                      }
+                    />
+                    <Button
+                      size="sm"
+                      variant="link"
+                      onClick={() => {
+                        setActiveStep(1)
+                      }}
+                    >
+                      Forgot your password?
+                    </Button>
+                  </div>
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <Button
+            type="submit"
+            disabled={isPending || !form.formState.isValid}
+            data-signedin={isSuccess}
+            className="mt-6 gap-1 data-[signedin=true]:bg-green-500 data-[signedin=true]:text-white transition-colors"
+          >
+            {isPending ? (
+              <>
+                <Icons.loader className="h-4 w-4 mr-2 animate-spin" /> Signing
+                In
+              </>
+            ) : isSuccess ? (
+              <>
+                <Icons.check className="w-4 h-4" /> Redirecting...
+              </>
+            ) : (
+              <>Sign In</>
+            )}
+          </Button>
+        </form>
+      </Form>
+      <p className="text-sm text-muted-foreground">
+        If you have any issues logging in, please contact support
+      </p>
+    </>
   )
 }
 

--- a/src/app/(auth)/(routes)/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/(auth)/(routes)/sign-in/[[...sign-in]]/page.tsx
@@ -3,7 +3,7 @@ import { appRoutes } from '@/lib/constants'
 import { auth } from '@clerk/nextjs'
 import Image from 'next/image'
 import { redirect } from 'next/navigation'
-import UserAuthForm from './components/user-auth-form'
+import MainForm from './components/main-form'
 
 export default async function Page({
   searchParams
@@ -54,18 +54,7 @@ export default async function Page({
                 />
               </div>
             </div>
-            <div className="flex flex-col space-y-4 text-center my-auto">
-              <h1 className="text-2xl font-semibold tracking-tight">
-                Login to community
-              </h1>
-              <p className="text-sm text-muted-foreground">
-                Enter your credentials to access your account
-              </p>
-              <UserAuthForm redirectUrl={redirectUrl} />
-              <p className="text-sm text-muted-foreground">
-                If you have any issues logging in, please contact support
-              </p>
-            </div>
+            <MainForm redirectUrl={redirectUrl} />
           </div>
         </div>
       </div>

--- a/src/app/api/password-recovery/route.ts
+++ b/src/app/api/password-recovery/route.ts
@@ -1,0 +1,28 @@
+import { sendEmailWithLink } from '@/actions/auth/send-email-with-link'
+import { passwordRecoveryEmailTemplate } from '@/lib/constants'
+import prismadb from '@/lib/prismadb'
+import { NextResponse, type NextRequest } from 'next/server'
+
+export async function POST(req: NextRequest) {
+  const { email } = await req.json()
+
+  try {
+    const userToRecoverPassword = await prismadb.user.findFirst({
+      where: { email }
+    })
+
+    if (!userToRecoverPassword)
+      return new NextResponse('User not found', { status: 404 })
+
+    await sendEmailWithLink(
+      userToRecoverPassword,
+      passwordRecoveryEmailTemplate,
+      'Recuperação de senha - Borderless Coding Community'
+    )
+
+    return NextResponse.json({ message: 'Email sent' }, { status: 200 })
+  } catch (error) {
+    console.log('[PASSWORD_RECOVERY_ERROR]', error)
+    return new NextResponse('Internal Server Error', { status: 500 })
+  }
+}

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,5 +1,6 @@
 import generatePassword from '@/actions/auth/generate-password'
 import { sendEmailWithLink } from '@/actions/auth/send-email-with-link'
+import { emailTemplate } from '@/lib/constants'
 import prismadb from '@/lib/prismadb'
 import { Roles } from '@/lib/types'
 import { auth, clerkClient } from '@clerk/nextjs'
@@ -133,7 +134,11 @@ export async function POST(req: NextRequest) {
       }
     })
 
-    await sendEmailWithLink(createdUser)
+    await sendEmailWithLink(
+      createdUser,
+      emailTemplate,
+      'Atualize sua senha - Borderless Coding Community'
+    )
 
     return NextResponse.json(createdUser)
   } catch (error) {

--- a/src/lib/constants.tsx
+++ b/src/lib/constants.tsx
@@ -175,3 +175,21 @@ Go Global or Nothing.
 <p>Yuri Pereira</p>
 </main>
 `
+
+export const passwordRecoveryEmailTemplate = (user: User, url: string) => `
+<main>
+<h1>Fala, ${user.name}!</h1>
+<span>Você solicitou a recuperação de sua senha.</span>
+<br />
+<p>Aqui está o link para você gerar uma nova senha de acesso a plataforma:
+</p>
+<a href="${url}">${url}</a>
+<p>
+  Se você não solicitou a recuperação de senha, por favor, ignore este e-mail.
+</p>
+<br />
+<p>
+  Equipe Borderless Coding Community
+</p>
+</main>
+`

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,7 +8,8 @@ export default authMiddleware({
     '/api/webhooks(.*)',
     '/api/auth/(.*)',
     '/api/uploadthing(.*)',
-    '/set-password/(.*)'
+    '/set-password/(.*)',
+    '/api/password-recovery(.*)'
   ]
 })
 


### PR DESCRIPTION
## Description
This PR adds the user flow to recover password from the sign-in page , the server-side route to handle its request and the email trigger, containing the URL to recover his password.

## What type of PR is this?
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 📦 Chore
- [ ] ⏩ Revert

## Screenshots:
- "Forgot your password" button:
![image](https://github.com/ProgramadoresSemPatria/sem-patria-community/assets/55456226/6372f7ee-77e1-498f-9c5e-b0b29a6fcdac)
- Password recover form step:
![image](https://github.com/ProgramadoresSemPatria/sem-patria-community/assets/55456226/41abcba1-d17d-4413-8f26-2e67d379abc6)
- Recovery submission loading state:
![image](https://github.com/ProgramadoresSemPatria/sem-patria-community/assets/55456226/1adb0c1b-d200-431d-a7ab-6b47fdbbbc60)
- Recovery submission failure state:
![image](https://github.com/ProgramadoresSemPatria/sem-patria-community/assets/55456226/466345bb-242b-4269-b119-ce1f86e800fa)
- Recovery submission success state:
![image](https://github.com/ProgramadoresSemPatria/sem-patria-community/assets/55456226/b7866467-ff53-4e88-b51e-dd89ada5002d)

