### PR TITLE
fix: minor improvements

### DIFF
--- a/src/app/(private)/(routes)/(member)/courses/components/course-card.tsx
+++ b/src/app/(private)/(routes)/(member)/courses/components/course-card.tsx
@@ -72,11 +72,13 @@ export const CourseCard = ({ courseProps: props }: CourseCardProps) => {
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <span className="mt-1 line-clamp-3 text-base font-medium dark:text-gray-100 text-black leading-snug text-ellipsis whitespace-nowrap">
+                  <span className="mt-1 text-base font-medium dark:text-gray-100 text-black leading-snug line-clamp-4">
                     {props.name}
                   </span>
                 </TooltipTrigger>
-                <TooltipContent>{props.name}</TooltipContent>
+                <TooltipContent className="max-w-[400px]">
+                  {props.name}
+                </TooltipContent>
               </Tooltip>
             </TooltipProvider>
           </div>

--- a/src/app/(private)/(routes)/admin/classroom/(routes)/[classroomId]/components/new-classroom-form/index.tsx
+++ b/src/app/(private)/(routes)/admin/classroom/(routes)/[classroomId]/components/new-classroom-form/index.tsx
@@ -78,7 +78,7 @@ export const NewClassroomForm = ({ initialData }: NewClassroomFormProps) => {
             onSubmit={form.handleSubmit(onSubmit)}
             className="space-y-8 w-full"
           >
-            <div className="grid grid-cols-3 gap-8">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-8">
               <FormField
                 control={form.control}
                 name="title"
@@ -109,12 +109,12 @@ export const NewClassroomForm = ({ initialData }: NewClassroomFormProps) => {
                       onValueChange={value => {
                         form.setValue('permissions', [value])
                       }}
-                      className="grid max-w-full grid-cols-2 gap-4 pt-2"
+                      className="flex flex-col flex-wrap gap-4 pt-2"
                     >
                       {Object.values(roles).map(value => (
                         <FormItem key={value}>
-                          <FormLabel className="flex items-center gap-x-2">
-                            <FormControl className="flex items-center gap-x-4">
+                          <FormLabel className="flex items-center gap-2">
+                            <FormControl className="flex items-center gap-4">
                               <RadioGroupItem
                                 value={value}
                                 checked={

--- a/src/app/(private)/(routes)/admin/classroom/(routes)/module/[moduleId]/components/new-classroom-module-form/index.tsx
+++ b/src/app/(private)/(routes)/admin/classroom/(routes)/module/[moduleId]/components/new-classroom-module-form/index.tsx
@@ -151,8 +151,8 @@ export const NewClassroomModuleForm = ({
                       ) : (
                         <div className="flex flex-col gap-y-2">
                           <span className="text-muted-foreground font-medium text-sm">
-                            You must create a classrom before create a module to
-                            him.
+                            You must create a classroom before create a module
+                            to him.
                           </span>
                           <Button
                             variant="secondary"

--- a/src/app/(private)/(routes)/admin/classroom/components/classroom-content/columns.tsx
+++ b/src/app/(private)/(routes)/admin/classroom/components/classroom-content/columns.tsx
@@ -26,7 +26,7 @@ export const columns: Array<ColumnDef<ClassroomColumn>> = [
     header: 'Permissions',
     cell: ({ row }) => {
       return (
-        <div className="flex items-center gap-x-3 flex-wrap">
+        <div className="flex items-center gap-2 flex-wrap">
           {row.original.permissions.map(value => (
             <Badge key={value}>{value}</Badge>
           ))}


### PR DESCRIPTION
## Classroom

- 'Permissions' column values overlapping
  - when using the platform on screens with smaller resolutions, the permission roles are overlapping.
  
![image](https://github.com/ProgramadoresSemPatria/sem-patria-community/assets/12905770/6d4f44c0-ca9e-41e7-831d-1aebe0cd46f7)

- The radio button does not appear
  - when creating a new classroom, the permission radio buttons are not being displayed


![image](https://github.com/ProgramadoresSemPatria/sem-patria-community/assets/12905770/2aace457-da88-46dc-b4cc-b8287a87b183)

![image](https://github.com/ProgramadoresSemPatria/sem-patria-community/assets/12905770/389433f0-fad7-4ce8-8b81-ef6e100b3a32)

## Courses

- Increased the number of allowed characters, but if it is too long, the card becomes distorted and aesthetically unpleasing. Therefore, it will truncate and add an ellipsis. By hovering over the card, the full title will be visible (the Tooltip is maintained).