### PR TITLE
fix: width issue when expanding notes in dashboard widget

### DIFF
--- a/src/app/(private)/(routes)/(member)/code-up/[noteId]/components/note-header/index.tsx
+++ b/src/app/(private)/(routes)/(member)/code-up/[noteId]/components/note-header/index.tsx
@@ -17,7 +17,7 @@ export const NoteHeader = ({ note, isPublicView = false }: NoteHeaderProps) => {
     router,
     handleSaveChanges,
     isPublicNote,
-    onChangeNoteVsibility
+    onChangeNoteVisibility
   } = useNoteHeader({ note })
 
   return (
@@ -29,6 +29,7 @@ export const NoteHeader = ({ note, isPublicView = false }: NoteHeaderProps) => {
           router.back()
           router.refresh()
         }}
+        className="w-36"
       >
         <Icons.arrowBack className="h-4 w-4 mr-2" />
         Back
@@ -38,7 +39,7 @@ export const NoteHeader = ({ note, isPublicView = false }: NoteHeaderProps) => {
           <div className="flex items-center space-x-2">
             <Label htmlFor="note-visibility">
               <span className="hidden sm:inline-flex mr-2">
-                Note visibilty:{' '}
+                Note visibility:{' '}
               </span>
               <span className="font-semibold">
                 {isPublicNote ? 'Public' : 'Private'}
@@ -47,14 +48,14 @@ export const NoteHeader = ({ note, isPublicView = false }: NoteHeaderProps) => {
             <Switch
               id="note-visibility"
               checked={isPublicNote}
-              onCheckedChange={onChangeNoteVsibility}
+              onCheckedChange={onChangeNoteVisibility}
             />
           </div>
           <Button
             variant="secondary"
             disabled={isPending}
             onClick={handleSaveChanges}
-            className="hidden sm:block"
+            className="hidden sm:flex"
           >
             {isPending && (
               <Icons.loader className="h-4 w-4 mr-2 animate-spin" />

--- a/src/app/(private)/(routes)/(member)/code-up/[noteId]/components/note-header/use-note-header.ts
+++ b/src/app/(private)/(routes)/(member)/code-up/[noteId]/components/note-header/use-note-header.ts
@@ -35,7 +35,7 @@ export const useNoteHeader = ({ note }: UseNoteHeaderProps) => {
     }
   )
 
-  const onChangeNoteVsibility = () => {
+  const onChangeNoteVisibility = () => {
     setIsPublicNote(prev => !prev)
   }
 
@@ -64,6 +64,6 @@ export const useNoteHeader = ({ note }: UseNoteHeaderProps) => {
     router,
     handleSaveChanges,
     isPublicNote,
-    onChangeNoteVsibility
+    onChangeNoteVisibility
   }
 }

--- a/src/app/(private)/(routes)/(member)/dashboard/components/timeline-notes-content.tsx
+++ b/src/app/(private)/(routes)/(member)/dashboard/components/timeline-notes-content.tsx
@@ -16,7 +16,7 @@ const TimelineNotesContent = ({
   noteId: string
 }) => {
   return (
-    <Collapsible className="flex-1">
+    <Collapsible className="relative max-w-lg">
       <div className="flex justify-center">
         <CollapsibleTrigger asChild>
           <Button className="p-2 gap-1" variant="ghost">

--- a/src/app/(private)/(routes)/(member)/dashboard/components/timeline-notes-content.tsx
+++ b/src/app/(private)/(routes)/(member)/dashboard/components/timeline-notes-content.tsx
@@ -8,15 +8,17 @@ import {
 } from '@/components/ui/collapsible'
 import Link from 'next/link'
 
+type TimelineNotesContentProps = {
+  content?: string | null
+  noteId: string
+}
+
 const TimelineNotesContent = ({
   content,
   noteId
-}: {
-  content: string | null | undefined
-  noteId: string
-}) => {
+}: TimelineNotesContentProps) => {
   return (
-    <Collapsible className="relative max-w-lg">
+    <Collapsible className="flex-1">
       <div className="flex justify-center">
         <CollapsibleTrigger asChild>
           <Button className="p-2 gap-1" variant="ghost">

--- a/src/app/(private)/(routes)/(member)/dashboard/components/timeline-notes.tsx
+++ b/src/app/(private)/(routes)/(member)/dashboard/components/timeline-notes.tsx
@@ -30,9 +30,9 @@ export const TimelineNotes = async ({ note, lastNote }: TimelineNotesProps) => {
             <Image src={avatarImg.src} alt="avatar" width={40} height={40} />
           </AvatarFallback>
         </Avatar>
-        <div className="flex flex-col gap-y-1 ml-2">
-          <span className="font-semibold text-sm">{note.title}</span>
-          <span className="font-semibold text-sm text-muted-foreground">
+        <div className="flex flex-col gap-y-1 ml-2 max-w-80">
+          <span className="font-semibold text-sm truncate">{note.title}</span>
+          <span className="font-semibold text-sm truncate text-muted-foreground">
             @{userProps?.username ?? 'unknown'}
           </span>
         </div>

--- a/src/app/(private)/(routes)/(member)/dashboard/components/timeline-notes.tsx
+++ b/src/app/(private)/(routes)/(member)/dashboard/components/timeline-notes.tsx
@@ -36,11 +36,9 @@ export const TimelineNotes = async ({ note, lastNote }: TimelineNotesProps) => {
             @{userProps?.username ?? 'unknown'}
           </span>
         </div>
-        <div className="ml-auto">
-          <span className="text-muted-foreground font-medium text-sm">
-            {format(note.updatedAt, 'MMMM dd, yyy')}
-          </span>
-        </div>
+        <span className="text-muted-foreground font-medium text-sm ml-auto">
+          {format(note.updatedAt, 'MMMM dd, yyy')}
+        </span>
       </div>
       <div className="w-full flex justify-center pb-3">
         <TimelineNotesContent content={note.content} noteId={note.id} />

--- a/src/app/(private)/(routes)/(member)/dashboard/components/timeline-notes.tsx
+++ b/src/app/(private)/(routes)/(member)/dashboard/components/timeline-notes.tsx
@@ -30,7 +30,7 @@ export const TimelineNotes = async ({ note, lastNote }: TimelineNotesProps) => {
             <Image src={avatarImg.src} alt="avatar" width={40} height={40} />
           </AvatarFallback>
         </Avatar>
-        <div className="flex flex-col gap-y-1 ml-2 max-w-80">
+        <div className="flex flex-col gap-y-1 ml-2 max-w-72">
           <span className="font-semibold text-sm truncate">{note.title}</span>
           <span className="font-semibold text-sm truncate text-muted-foreground">
             @{userProps?.username ?? 'unknown'}

--- a/src/app/(private)/(routes)/(member)/forum/[postId]/components/comment-section.tsx
+++ b/src/app/(private)/(routes)/(member)/forum/[postId]/components/comment-section.tsx
@@ -16,8 +16,8 @@ import { ForumCommentComponent } from './forum-comment-component'
 import SendCommentButton from './send-comment-button'
 import { usePostComments } from './use-post-comments'
 interface CommentSectionProps {
-  postId: string | undefined
-  comments: ExtendedComment[] | undefined
+  postId?: string
+  comments?: ExtendedComment[]
 }
 
 const CommentSection = ({ postId, comments }: CommentSectionProps) => {

--- a/src/app/(private)/(routes)/(member)/forum/[postId]/components/reply-comment-section/index.tsx
+++ b/src/app/(private)/(routes)/(member)/forum/[postId]/components/reply-comment-section/index.tsx
@@ -14,7 +14,7 @@ import SendCommentButton from '../send-comment-button'
 import { useReplyCommentSection } from './use-reply-comment-section'
 
 type CommentSectionProps = {
-  commentId: string | undefined
+  commentId?: string
   replyToId: string | null
   replies: ExtendedComment[]
   likes: ExtendedComment['likes']

--- a/src/app/(private)/(routes)/(member)/forum/[postId]/components/reply-comment-section/use-reply-comment-section.ts
+++ b/src/app/(private)/(routes)/(member)/forum/[postId]/components/reply-comment-section/use-reply-comment-section.ts
@@ -7,7 +7,7 @@ import { useEffect, useReducer, useState } from 'react'
 import { type ExtendedComment } from '../../page'
 
 type UseReplyCommentSectionProps = {
-  commentId: string | undefined
+  commentId?: string
   replies: ExtendedComment[]
   likes: ExtendedComment['likes']
 }

--- a/src/app/(private)/(routes)/(member)/mentorship/components/mentorship-sections/index.tsx
+++ b/src/app/(private)/(routes)/(member)/mentorship/components/mentorship-sections/index.tsx
@@ -66,7 +66,7 @@ export const MentorshipSections = async () => {
         {!formattedData.length && (
           <NoContent
             title="No classrooms created yet."
-            description="Try contact the for any admin to add a new content."
+            description="Try contacting an admin to add new content."
           />
         )}
         {formattedData.map(classroom => (

--- a/src/app/(private)/(routes)/admin/classroom/page.tsx
+++ b/src/app/(private)/(routes)/admin/classroom/page.tsx
@@ -9,7 +9,7 @@ import VideoContent from './components/classroom-video-content'
 const AdminClassroomPage = ({
   searchParams
 }: {
-  searchParams?: Record<string, string | string[] | undefined>
+  searchParams?: Record<string, string | string[]>
 }) => {
   const tabSelected = searchParams?.tabSelected as string
 


### PR DESCRIPTION
## Changes

- Fixed width issue when expanding notes in the dashboard widget:
  - Resolved distortion of the date on the right side in expanded mode.
- Corrected inconsistent button width for "Save Changes" during the loading state in the CodeUp note editor.
- Fix small typos
- Omit explicit `undefined` from types and use `?:` instead

## Screenshots

Normal state (without collapsing):

![image](https://github.com/ProgramadoresSemPatria/sem-patria-community/assets/12905770/5cbcf130-d7dc-491b-a279-d26cf63a5170)

Expanded state (collapsed):

![image](https://github.com/ProgramadoresSemPatria/sem-patria-community/assets/12905770/381060c6-01d9-4db9-8619-436ffa782d6f)

![image](https://github.com/ProgramadoresSemPatria/sem-patria-community/assets/12905770/f5f3416c-f70b-4a08-ae56-01ddaeac1db5)

