### PR TITLE
chore: add migrate script to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "postinstall": "prisma generate && husky install",
     "commit": "cz",
     "check-types": "tsc --noEmit --pretty",
-    "cypress:open": "cypress open"
+    "cypress:open": "cypress open",
+    "migrate": "prisma migrate"
   },
   "dependencies": {
     "@blocknote/core": "^0.10.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "commit": "cz",
     "check-types": "tsc --noEmit --pretty",
     "cypress:open": "cypress open",
-    "migrate": "prisma migrate"
+    "prisma-migrate": "prisma migrate dev"
   },
   "dependencies": {
     "@blocknote/core": "^0.10.1",


### PR DESCRIPTION
The readme asks to use the command "pnpm migrate dev" To set up the database schema and apply any pending migrations but i was getting the error "Command "migrate" not found" to solve it i added migrate script to the package.json