### PR TITLE
fix: adding delete attachment button validation

### DIFF
--- a/src/app/(private)/(routes)/(member)/mentorship/[videoId]/components/mentorship-tab/index.tsx
+++ b/src/app/(private)/(routes)/(member)/mentorship/[videoId]/components/mentorship-tab/index.tsx
@@ -1,5 +1,9 @@
 'use client'
+import { UploadFilesModule } from '@/app/(private)/(routes)/admin/classroom/(routes)/video/[videoId]/components/new-classroom-video-form/upload-file-module'
+import FilesPreview from '@/app/(private)/(routes)/admin/classroom/(routes)/video/[videoId]/components/new-classroom-video-form/upload-file-module/files-preview'
+import { useNewClassroomVideoForm } from '@/app/(private)/(routes)/admin/classroom/(routes)/video/[videoId]/components/new-classroom-video-form/use-new-classroom-video-form'
 import { Icons } from '@/components/icons'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import {
   Tooltip,
@@ -7,19 +11,15 @@ import {
   TooltipProvider,
   TooltipTrigger
 } from '@/components/ui/tooltip'
-import { appRoutes } from '@/lib/constants'
-import { cn } from '@/lib/utils'
-import Link from 'next/link'
-import { TabTypes, useMentorshipTab } from './use-mentorship-tab'
-import { Reorder } from 'framer-motion'
-import { useState } from 'react'
 import { AbilityContext } from '@/hooks/use-ability'
-import { useAbility } from '@casl/react'
-import { Button } from '@/components/ui/button'
+import { appRoutes } from '@/lib/constants'
 import { type VideoWithAttachments } from '@/lib/types'
-import { UploadFilesModule } from '@/app/(private)/(routes)/admin/classroom/(routes)/video/[videoId]/components/new-classroom-video-form/upload-file-module'
-import { useNewClassroomVideoForm } from '@/app/(private)/(routes)/admin/classroom/(routes)/video/[videoId]/components/new-classroom-video-form/use-new-classroom-video-form'
-import FilesPreview from '@/app/(private)/(routes)/admin/classroom/(routes)/video/[videoId]/components/new-classroom-video-form/upload-file-module/files-preview'
+import { cn } from '@/lib/utils'
+import { useAbility } from '@casl/react'
+import { Reorder } from 'framer-motion'
+import Link from 'next/link'
+import { useState } from 'react'
+import { TabTypes, useMentorshipTab } from './use-mentorship-tab'
 
 type MentorshipTabProps = {
   videoProps: VideoWithAttachments
@@ -41,7 +41,7 @@ const MentorshipTab = ({ videoProps, moduleVideos }: MentorshipTabProps) => {
   })
   const ability = useAbility(AbilityContext)
   const canManageVideos = ability.can('manage', 'all')
-  const canManageAttachments = ability.can('manage', 'all')
+  const canManageAttachments = ability.can('manageAttachments', 'Mentorship')
 
   const [videos, setVideos] = useState(moduleVideos)
   const [showAddAttachments, setShowAddAttachments] = useState(false)

--- a/src/app/(private)/(routes)/(member)/mentorship/[videoId]/components/mentorship-tab/index.tsx
+++ b/src/app/(private)/(routes)/(member)/mentorship/[videoId]/components/mentorship-tab/index.tsx
@@ -41,6 +41,7 @@ const MentorshipTab = ({ videoProps, moduleVideos }: MentorshipTabProps) => {
   })
   const ability = useAbility(AbilityContext)
   const canManageVideos = ability.can('manage', 'all')
+  const canManageAttachments = ability.can('manage', 'all')
 
   const [videos, setVideos] = useState(moduleVideos)
   const [showAddAttachments, setShowAddAttachments] = useState(false)
@@ -202,14 +203,16 @@ const MentorshipTab = ({ videoProps, moduleVideos }: MentorshipTabProps) => {
                   >
                     {file.name}
                   </Link>
-                  <Icons.trash
-                    onClick={async e => {
-                      e.stopPropagation()
-                      e.preventDefault()
-                      await onDeleteAttachment(file.id)
-                    }}
-                    className="h-4 w-4 ml-2 text-rose-600 hover:cursor-pointer"
-                  />
+                  {canManageAttachments && (
+                    <Icons.trash
+                      onClick={async e => {
+                        e.stopPropagation()
+                        e.preventDefault()
+                        await onDeleteAttachment(file.id)
+                      }}
+                      className="h-4 w-4 ml-2 text-rose-600 hover:cursor-pointer"
+                    />
+                  )}
                 </div>
               ))}
             </div>

--- a/src/app/(private)/(routes)/(member)/mentorship/[videoId]/components/mentorship-tab/index.tsx
+++ b/src/app/(private)/(routes)/(member)/mentorship/[videoId]/components/mentorship-tab/index.tsx
@@ -40,7 +40,7 @@ const MentorshipTab = ({ videoProps, moduleVideos }: MentorshipTabProps) => {
     initialData: videoProps
   })
   const ability = useAbility(AbilityContext)
-  const canManageVideos = ability.can('manage', 'all')
+  const canManageVideos = ability.can('manageVideos', 'Mentorship')
   const canManageAttachments = ability.can('manageAttachments', 'Mentorship')
 
   const [videos, setVideos] = useState(moduleVideos)

--- a/src/lib/casl/ability.ts
+++ b/src/lib/casl/ability.ts
@@ -5,13 +5,14 @@ import { z } from 'zod'
 import { permissions } from '../permissions'
 import { type UserAbilityRoles } from '../types'
 import {
+  mentorshipSubject,
   categorySubject,
   classroomSubject,
   cmsSubject,
   courseSubject,
   eventSubject,
-  userSubject,
-  postSubject
+  postSubject,
+  userSubject
 } from './subjects'
 
 const appAbilitiesSchema = z.union([
@@ -22,7 +23,7 @@ const appAbilitiesSchema = z.union([
   classroomSubject,
   cmsSubject,
   postSubject,
-
+  mentorshipSubject,
   z.tuple([z.literal('manage'), z.literal('all')])
 ])
 export type AppAbilities = z.infer<typeof appAbilitiesSchema>

--- a/src/lib/casl/entities/mentorship.ts
+++ b/src/lib/casl/entities/mentorship.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod'
+
+export const mentorshipSchema = z.object({
+  __typename: z.literal('Mentorship').default('Mentorship')
+})

--- a/src/lib/casl/subjects/index.ts
+++ b/src/lib/casl/subjects/index.ts
@@ -84,7 +84,8 @@ export const mentorshipSubject = z.tuple([
     z.literal('create'),
     z.literal('update'),
     z.literal('delete'),
-    z.literal('manageAttachments')
+    z.literal('manageAttachments'),
+    z.literal('manageVideos')
   ]),
   z.union([z.literal('Mentorship'), mentorshipSchema])
 ])

--- a/src/lib/casl/subjects/index.ts
+++ b/src/lib/casl/subjects/index.ts
@@ -3,8 +3,9 @@ import { categorySchema } from '../entities/category'
 import { classroomSchema } from '../entities/classroom'
 import { courseSchema } from '../entities/course'
 import { eventSchema } from '../entities/event'
-import { userSchema } from '../entities/user'
+import { mentorshipSchema } from '../entities/mentorship'
 import { postSchema } from '../entities/post'
+import { userSchema } from '../entities/user'
 
 export const userSubject = z.tuple([
   z.union([
@@ -75,3 +76,15 @@ export const postSubject = z.tuple([
 ])
 
 export const cmsSubject = z.tuple([z.literal('get'), z.literal('CMS')])
+
+export const mentorshipSubject = z.tuple([
+  z.union([
+    z.literal('manage'),
+    z.literal('get'),
+    z.literal('create'),
+    z.literal('update'),
+    z.literal('delete'),
+    z.literal('manageAttachments')
+  ]),
+  z.union([z.literal('Mentorship'), mentorshipSchema])
+])


### PR DESCRIPTION
## Description
This PR fixes the missing validation for the "delete attachment" button, at the mentorship video attachments tab.

## What type of PR is this?
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 📦 Chore
- [ ] ⏩ Revert

## Screenshots
![image](https://github.com/user-attachments/assets/e183d9df-0d60-4352-b2eb-9ea6fc718ea5)

