### PR TITLE
Fix: delete user refactor logic

### DIFF
--- a/prisma/migrations/20241020192008_add_is_disabled_in_user_model/migration.sql
+++ b/prisma/migrations/20241020192008_add_is_disabled_in_user_model/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "isDisabled" BOOLEAN DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,7 +25,6 @@ model User {
   imageUrl     String?
   lastLogin    DateTime?
   isDisabled   Boolean?      @default(false)
-  notes        Note[]
 
   comments     Comment[]
   commentLikes CommentLike[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,7 @@ model User {
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
   lastLogin    DateTime?
+  isDisabled   Boolean?      @default(false)
   notes        Note[]
   comments     Comment[]
   likes        Like[]

--- a/src/app/(private)/(routes)/admin/users/[userId]/components/new-user-form/use-new-user-form.ts
+++ b/src/app/(private)/(routes)/admin/users/[userId]/components/new-user-form/use-new-user-form.ts
@@ -130,6 +130,41 @@ export const useNewUserForm = ({ initialData }: UseNewUserFormProps) => {
     }
   }
 
+  const { mutateAsync: enableUser, isPending: isEnablingUser } = useMutation({
+    mutationFn: async () => {
+      return await api.patch(`/api/user/${params.userId}/enable`)
+    },
+    onSuccess: () => {
+      router.push(appRoutes.admin_users)
+      router.refresh()
+      toast({
+        title: 'Success',
+        description: 'User was enabled successfully.'
+      })
+    },
+    onError: error => {
+      toast({
+        title: 'Error',
+        description: error.message ?? 'Something went wrong.',
+        variant: 'destructive'
+      })
+    }
+  })
+
+  const onEnableUser = async () => {
+    try {
+      await enableUser()
+    } catch (error) {
+      toast({
+        title: 'Error',
+        description: 'Something went wrong.',
+        variant: 'destructive'
+      })
+    } finally {
+      setIsAlertModalOpen(false)
+    }
+  }
+
   const { mutateAsync: createOrUpdateUser, isPending } = useMutation({
     mutationFn: async (data: z.infer<typeof formSchema>) => {
       if (initialData) {
@@ -192,6 +227,8 @@ export const useNewUserForm = ({ initialData }: UseNewUserFormProps) => {
     onSubmit,
     selectedRoles,
     handleSelectedRoles,
-    action
+    action,
+    onEnableUser,
+    isEnablingUser
   }
 }

--- a/src/app/(private)/(routes)/admin/users/components/columns.tsx
+++ b/src/app/(private)/(routes)/admin/users/components/columns.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Icons } from '@/components/icons'
+import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Roles } from '@/lib/types'
 import { type ColumnDef } from '@tanstack/react-table'
@@ -19,6 +20,7 @@ export type UserColumn = {
   lastAccess: Date | null
   level: string | null
   role: string[] | null
+  isDisabled?: boolean
 }
 
 export const userColumns: Array<ColumnDef<UserColumn>> = [
@@ -93,6 +95,23 @@ export const userColumns: Array<ColumnDef<UserColumn>> = [
       )
 
       return <UserCellRoles roles={rolesMapped} />
+    }
+  },
+  {
+    accessorKey: 'isDisabled',
+    header: 'Status',
+    cell: cell => {
+      return (
+        <Badge
+          className={
+            cell.getValue()
+              ? 'bg-red-950 text-red-500 border border-red-900 hover:bg-red-900'
+              : 'bg-emerald-950 text-emerald-500 border border-emerald-900 hover:bg-emerald-900'
+          }
+        >
+          {cell.getValue() ? 'Disabled' : 'Active'}
+        </Badge>
+      )
     }
   },
   {

--- a/src/app/(private)/(routes)/admin/users/components/user-cell-action.tsx
+++ b/src/app/(private)/(routes)/admin/users/components/user-cell-action.tsx
@@ -63,16 +63,60 @@ export const UserCellAction = ({ data }: UserCellActionProps) => {
     }
   }
 
+  const { mutateAsync: enableUser, isPending: isEnablingUser } = useMutation({
+    mutationFn: async () => {
+      return await api.patch(`/api/user/${data.id}/enable`)
+    },
+    onSuccess: () => {
+      router.push(appRoutes.admin_users)
+      router.refresh()
+      toast({
+        title: 'Success',
+        description: 'User was enabled successfully.'
+      })
+    },
+    onError: error => {
+      toast({
+        title: 'Error',
+        description: error.message ?? 'Something went wrong.',
+        variant: 'destructive'
+      })
+    }
+  })
+
+  const onEnableUser = async () => {
+    try {
+      await enableUser()
+    } catch (error) {
+      toast({
+        title: 'Error',
+        description: 'Something went wrong.',
+        variant: 'destructive'
+      })
+    } finally {
+      setIsAlertModalOpen(false)
+    }
+  }
+
   return (
     <>
       <AlertModal
         isOpen={isAlertModalOpen}
-        description="Are you sure you want to delete this user?"
+        description={`This action will ${
+          data?.isDisabled ? 'enable' : 'disable'
+        } this user account, are you sure?`}
+        confirmationTitle={data?.isDisabled ? 'Enable' : 'Delete'}
+        loading={isDeleting || isEnablingUser}
         onClose={() => {
           setIsAlertModalOpen(false)
         }}
-        onConfirm={onDeleteUser}
-        loading={isDeleting}
+        onConfirm={async () => {
+          if (data?.isDisabled) {
+            await onEnableUser()
+            return
+          }
+          await onDeleteUser()
+        }}
       />
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
@@ -96,9 +140,19 @@ export const UserCellAction = ({ data }: UserCellActionProps) => {
               onClick={() => {
                 setIsAlertModalOpen(true)
               }}
+              disabled={data.isDisabled}
             >
               <Icons.trash className="mr-2 h-4 w-4" />
               Delete
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => {
+                setIsAlertModalOpen(true)
+              }}
+              disabled={!data.isDisabled}
+            >
+              <Icons.userCheck className="mr-2 h-4 w-4" />
+              Enable
             </DropdownMenuItem>
           </Can>
         </DropdownMenuContent>

--- a/src/app/(private)/(routes)/admin/users/page.tsx
+++ b/src/app/(private)/(routes)/admin/users/page.tsx
@@ -16,7 +16,8 @@ const AdminUsersPage = async () => {
     lastAccess: item.lastLogin,
     level: item.level,
     imageUrl: item.imageUrl,
-    role: item.role
+    role: item.role,
+    isDisabled: item?.isDisabled || false
   }))
 
   return (

--- a/src/app/api/user/[userId]/enable/route.ts
+++ b/src/app/api/user/[userId]/enable/route.ts
@@ -1,0 +1,36 @@
+import prismadb from '@/lib/prismadb'
+import { auth } from '@clerk/nextjs/server'
+import { NextResponse, type NextRequest } from 'next/server'
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { userId: string } }
+) {
+  try {
+    const { userId } = auth()
+
+    if (!userId) return new NextResponse('Unauthenticated', { status: 401 })
+
+    if (!params.userId)
+      return new NextResponse('User id required', { status: 400 })
+
+    let user = {}
+    try {
+      user = await prismadb.user.update({
+        where: {
+          id: params.userId
+        },
+        data: {
+          isDisabled: false
+        }
+      })
+    } catch (dbError) {
+      console.log('[DB_USER_ENABLE_ERROR]', dbError)
+    }
+
+    return NextResponse.json(user)
+  } catch (error) {
+    console.log('[USER_ENABLE_ERROR]', error)
+    return new NextResponse('Internal Server Error', { status: 500 })
+  }
+}

--- a/src/app/api/user/[userId]/enable/route.ts
+++ b/src/app/api/user/[userId]/enable/route.ts
@@ -1,5 +1,5 @@
 import prismadb from '@/lib/prismadb'
-import { auth } from '@clerk/nextjs/server'
+import { auth, clerkClient } from '@clerk/nextjs/server'
 import { NextResponse, type NextRequest } from 'next/server'
 
 export async function PATCH(
@@ -13,6 +13,12 @@ export async function PATCH(
 
     if (!params.userId)
       return new NextResponse('User id required', { status: 400 })
+
+    try {
+      await clerkClient.users.unbanUser(params.userId)
+    } catch (clerkError) {
+      console.log('[CLERK_USER_ENABLE_ERROR]', clerkError)
+    }
 
     let user = {}
     try {

--- a/src/app/api/user/[userId]/route.ts
+++ b/src/app/api/user/[userId]/route.ts
@@ -15,9 +15,9 @@ export async function DELETE(
       return new NextResponse('User id required', { status: 400 })
 
     try {
-      await clerkClient.users.deleteUser(params.userId)
+      await clerkClient.users.banUser(params.userId)
     } catch (clerkError) {
-      console.log('[CLERK_USER_DELETE_ERROR]', clerkError)
+      console.log('[CLERK_USER_DISABLE_ERROR]', clerkError)
     }
 
     let user = {}

--- a/src/app/api/user/[userId]/route.ts
+++ b/src/app/api/user/[userId]/route.ts
@@ -13,15 +13,26 @@ export async function DELETE(
 
     if (!params.userId)
       return new NextResponse('User id required', { status: 400 })
-    // Delete user at Clerk
-    await clerkClient.users.deleteUser(params.userId)
 
-    // Delete user at DB
-    const user = await prismadb.user.delete({
-      where: {
-        id: params.userId
-      }
-    })
+    try {
+      await clerkClient.users.deleteUser(params.userId)
+    } catch (clerkError) {
+      console.log('[CLERK_USER_DELETE_ERROR]', clerkError)
+    }
+
+    let user = {}
+    try {
+      user = await prismadb.user.update({
+        where: {
+          id: params.userId
+        },
+        data: {
+          isDisabled: true
+        }
+      })
+    } catch (dbError) {
+      console.log('[DB_USER_DELETE_ERROR]', dbError)
+    }
 
     return NextResponse.json(user)
   } catch (error) {

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -75,7 +75,9 @@ import {
   Youtube,
   type LucideIcon,
   Save,
-  GripVertical
+  GripVertical,
+  UserX,
+  UserCheck
 } from 'lucide-react'
 
 export type IconType = LucideIcon
@@ -157,5 +159,7 @@ export const Icons = {
   youtube: Youtube,
   forum: MessageSquare,
   dot: Dot,
-  save: Save
+  save: Save,
+  userX: UserX,
+  userCheck: UserCheck
 }

--- a/src/components/modals/alert-modal.tsx
+++ b/src/components/modals/alert-modal.tsx
@@ -12,6 +12,7 @@ type AlertModalProps = {
   description: string
   onConfirm: () => void
   onClose: () => void
+  confirmationTitle?: string
 }
 
 export const AlertModal = ({
@@ -20,7 +21,8 @@ export const AlertModal = ({
   title,
   description,
   onClose,
-  onConfirm
+  onConfirm,
+  confirmationTitle = 'Delete'
 }: AlertModalProps) => {
   const [isMounted, setIsMounted] = useState(false)
 
@@ -59,7 +61,7 @@ export const AlertModal = ({
           }}
         >
           {loading && <Icons.loader className="mr-2 h-4 w-4 animate-spin" />}
-          Delete
+          {confirmationTitle}
         </Button>
       </div>
     </Modal>


### PR DESCRIPTION
## Description
This PR adds updates to the "delete a user" workflow. It adds a new optional property to user schema "_isDisabled_", and updates the user delete route logic with Clerk integration, now using a "soft delete" approach.

## What type of PR is this?
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 📦 Chore
- [ ] ⏩ Revert

## Screenshots
- New **status** column at users list:
![CleanShot 2024-10-22 at 23 14 38@2x](https://github.com/user-attachments/assets/e068a25d-03d7-4431-9196-041d8b14497f)
- Quick "Delete" action, since user is currently Active:
![CleanShot 2024-10-22 at 23 15 00@2x](https://github.com/user-attachments/assets/85ac8fc4-c406-4c17-bea4-3c19c94495a7)
- Quick "Enable" action, since user is currently Disabled:
![CleanShot 2024-10-22 at 23 15 31@2x](https://github.com/user-attachments/assets/8b751d4b-5798-46b1-9b7e-543db16a264b)
- New "Enable user" button at user update page:
![CleanShot 2024-10-22 at 23 15 55@2x](https://github.com/user-attachments/assets/9ff9fcb9-5583-42db-b762-5652f822b03e)

