### PR TITLE
Refactor: toggle email public at user profile

### DIFF
--- a/prisma/migrations/20241030173021_add_is_public_email_attribute_on_user/migration.sql
+++ b/prisma/migrations/20241030173021_add_is_public_email_attribute_on_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "isPublicEmail" BOOLEAN DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,23 +18,25 @@ enum Roles {
 }
 
 model User {
-  id           String        @id @default(uuid())
-  email        String
-  password     String?
-  name         String
-  username     String
-  level        String?
-  role         Roles[]       @default([])
-  github       String?
-  linkedin     String?
-  instagram    String?
-  imageUrl     String?
-  followers    Int           @default(0)
-  followings   Int           @default(0)
-  createdAt    DateTime      @default(now())
-  updatedAt    DateTime      @updatedAt
-  lastLogin    DateTime?
-  isDisabled   Boolean?      @default(false)
+  id            String    @id @default(uuid())
+  email         String
+  password      String?
+  name          String
+  username      String
+  level         String?
+  role          Roles[]   @default([])
+  github        String?
+  linkedin      String?
+  instagram     String?
+  imageUrl      String?
+  followers     Int       @default(0)
+  followings    Int       @default(0)
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+  lastLogin     DateTime?
+  isDisabled    Boolean?  @default(false)
+  isPublicEmail Boolean?  @default(false)
+
   notes        Note[]
   comments     Comment[]
   likes        Like[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,27 +20,27 @@ enum Roles {
 model User {
   id            String    @id @default(uuid())
   email         String
-  password      String?
   name          String
   username      String
   level         String?
-  role          Roles[]   @default([])
-  github        String?
-  linkedin      String?
-  instagram     String?
-  imageUrl      String?
-  followers     Int       @default(0)
-  followings    Int       @default(0)
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
+  followers     Int       @default(0)
+  followings    Int       @default(0)
+  github        String?
+  instagram     String?
+  linkedin      String?
+  password      String?
+  role          Roles[]   @default([])
+  imageUrl      String?
   lastLogin     DateTime?
   isDisabled    Boolean?  @default(false)
   isPublicEmail Boolean?  @default(false)
 
-  notes        Note[]
   comments     Comment[]
-  likes        Like[]
   commentLikes CommentLike[]
+  likes        Like[]
+  notes        Note[]
   posts        Post[]
 }
 

--- a/src/app/(private)/(routes)/(member)/profile/components/personal-info.tsx
+++ b/src/app/(private)/(routes)/(member)/profile/components/personal-info.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
 import { isObjEmpty } from '@/lib/utils'
 import { useUser } from '@clerk/nextjs'
 import { type User } from '@prisma/client'
@@ -40,6 +41,9 @@ export const PersonalInfo = ({ userProps }: PersonalInfoProps) => {
         imageUrl: userProps.imageUrl || user?.imageUrl || ''
       }
     })
+
+  const { watch, setValue } = form
+  const isPublicEmail = watch('isPublicEmail')
 
   return (
     <div>
@@ -134,7 +138,7 @@ export const PersonalInfo = ({ userProps }: PersonalInfoProps) => {
                   )}
                 />
               </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 items-start gap-2 sm:gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-3 items-start gap-2 sm:gap-4">
                 <div className="flex flex-col gap-y-2">
                   <Label htmlFor="email">Email</Label>
                   <Input
@@ -145,6 +149,47 @@ export const PersonalInfo = ({ userProps }: PersonalInfoProps) => {
                     value={user.emailAddresses[0].emailAddress || ''}
                   />
                 </div>
+                <FormField
+                  control={form.control}
+                  name="isPublicEmail"
+                  disabled={isUpdating}
+                  render={({ field }) => (
+                    <FormItem className="flex flex-col gap-y-2 space-y-0">
+                      <FormLabel>Turn Email Public?</FormLabel>
+                      <FormControl>
+                        <div
+                          className="group inline-flex items-center gap-2 h-9 rounded-md border border-input shadow-sm"
+                          data-state={isPublicEmail ? 'checked' : 'unchecked'}
+                        >
+                          <span
+                            id="switch-off-label"
+                            className="flex-1 cursor-pointer text-right text-sm font-medium group-data-[state=checked]:text-muted-foreground/70"
+                            onClick={() => {
+                              setValue('isPublicEmail', false)
+                            }}
+                          >
+                            Off
+                          </span>
+                          <Switch
+                            id="is_public_email"
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                          <span
+                            id="switch-on-label"
+                            className="flex-1 cursor-pointer text-left text-sm font-medium group-data-[state=unchecked]:text-muted-foreground/70"
+                            onClick={() => {
+                              setValue('isPublicEmail', true)
+                            }}
+                          >
+                            On
+                          </span>
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
                 <FormField
                   control={form.control}
                   name="level"

--- a/src/app/(private)/(routes)/(member)/profile/components/use-personal-info.ts
+++ b/src/app/(private)/(routes)/(member)/profile/components/use-personal-info.ts
@@ -63,7 +63,8 @@ export const personalInfoSchema = z
     newPassword: z
       .string()
       .min(8, { message: 'Password must be at least 8 characters long' })
-      .optional()
+      .optional(),
+    isPublicEmail: z.boolean().optional()
   })
   .superRefine(({ passwordConfirmation, password, newPassword }, ctx) => {
     if (password && !passwordConfirmation) {
@@ -108,7 +109,8 @@ const usePersonalInfo = ({ userProps }: PersonalInfoProps) => {
       username:
         userProps.username ||
         (userProps.username === '' ? userProps.github ?? undefined : undefined),
-      imageUrl: userProps.imageUrl ?? undefined
+      imageUrl: userProps.imageUrl ?? undefined,
+      isPublicEmail: userProps.isPublicEmail ?? false
     },
     values: {
       userId: userProps.id ?? undefined,
@@ -120,7 +122,8 @@ const usePersonalInfo = ({ userProps }: PersonalInfoProps) => {
       username:
         userProps.username ||
         (userProps.username === '' ? userProps.github ?? '' : ''),
-      imageUrl: userProps.imageUrl ?? undefined
+      imageUrl: userProps.imageUrl ?? undefined,
+      isPublicEmail: userProps.isPublicEmail ?? false
     }
   })
 

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -23,7 +23,8 @@ export async function PATCH(req: NextRequest) {
       password,
       passwordConfirmation,
       newPassword,
-      imageUrl
+      imageUrl,
+      isPublicEmail
     } = await req.json()
 
     if (!authUserId) return new NextResponse('Unauthenticated', { status: 401 })
@@ -106,7 +107,8 @@ export async function PATCH(req: NextRequest) {
         instagram,
         level,
         linkedin,
-        role
+        role,
+        isPublicEmail
       }
     })
 


### PR DESCRIPTION
## Description
This PR adds a new property to the user schema- "isPublicEmail"- and a new toggle component to the user profile to update this property. This property will control rather if user displays or not his email at his public profile.

## What type of PR is this?
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 📦 Chore
- [ ] ⏩ Revert

## Screenshots:
![CleanShot 2024-10-30 at 15 23 56@2x](https://github.com/user-attachments/assets/fa7ee192-eb64-418f-8105-845f87ab8d0f)
![CleanShot 2024-10-30 at 15 24 27@2x](https://github.com/user-attachments/assets/91d07bab-7b0f-4f03-9d8c-25d0cbdb30ab)

