### PR TITLE
Refactor: users table new props

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@tiptap/starter-kit": "^2.2.4",
     "@uploadthing/react": "^6.5.1",
     "@vercel/analytics": "^1.3.1",
+    "@vis.gl/react-google-maps": "^1.4.0",
     "axios": "^1.6.2",
     "bcrypt": "^5.1.1",
     "class-variance-authority": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.3.1
         version: 1.3.1(next@14.2.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+      '@vis.gl/react-google-maps':
+        specifier: ^1.4.0
+        version: 1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       axios:
         specifier: ^1.6.2
         version: 1.6.2
@@ -1899,6 +1902,9 @@ packages:
   '@types/extend@3.0.4':
     resolution: {integrity: sha512-ArMouDUTJEz1SQRpFsT2rIw7DeqICFv5aaVzLSIYMYQSLcwcGOfT3VyglQs/p7K3F7fT4zxr0NWxYZIdifD6dA==}
 
+  '@types/google.maps@3.58.1':
+    resolution: {integrity: sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==}
+
   '@types/hast@2.3.9':
     resolution: {integrity: sha512-pTHyNlaMD/oKJmS+ZZUyFUcsZeBZpC0lmGquw98CqRVNgAdJZJeD7GoeLiT6Xbx5rU9VCjSt0RwEvDgzh4obFw==}
 
@@ -2177,6 +2183,12 @@ packages:
         optional: true
       react:
         optional: true
+
+  '@vis.gl/react-google-maps@1.4.0':
+    resolution: {integrity: sha512-M2pW1NjLGlT/HAMqtd3vWPfrlPh9wgcxVlnSmwCtmEJYzNV9ihiUz1awp7LHzsDoJ2XV0DuD4bwmnElKbxt9Ug==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -7863,6 +7875,8 @@ snapshots:
 
   '@types/extend@3.0.4': {}
 
+  '@types/google.maps@3.58.1': {}
+
   '@types/hast@2.3.9':
     dependencies:
       '@types/unist': 2.0.10
@@ -8178,6 +8192,13 @@ snapshots:
     optionalDependencies:
       next: 14.2.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+
+  '@vis.gl/react-google-maps@1.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@types/google.maps': 3.58.1
+      fast-deep-equal: 3.1.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
 
   JSONStream@1.3.5:
     dependencies:

--- a/prisma/migrations/20241105190621_add_location_attribute_on_user/migration.sql
+++ b/prisma/migrations/20241105190621_add_location_attribute_on_user/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "Positions" AS ENUM ('AMBASSADOR', 'BUILDER', 'PSP', 'BASE', 'ADMIN');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "location" TEXT,
+ADD COLUMN     "position" "Positions";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,25 +17,35 @@ enum Roles {
   Admin
 }
 
+enum Positions {
+  AMBASSADOR
+  BUILDER
+  PSP
+  BASE
+  ADMIN
+}
+
 model User {
-  id            String    @id @default(uuid())
+  id            String     @id @default(uuid())
   email         String
   name          String
   username      String
   level         String?
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
-  followers     Int       @default(0)
-  followings    Int       @default(0)
+  createdAt     DateTime   @default(now())
+  updatedAt     DateTime   @updatedAt
+  followers     Int        @default(0)
+  followings    Int        @default(0)
   github        String?
   instagram     String?
   linkedin      String?
   password      String?
-  role          Roles[]   @default([])
+  role          Roles[]    @default([])
   imageUrl      String?
   lastLogin     DateTime?
-  isDisabled    Boolean?  @default(false)
-  isPublicEmail Boolean?  @default(false)
+  isDisabled    Boolean?   @default(false)
+  isPublicEmail Boolean?   @default(false)
+  position      Positions?
+  location      String?
 
   comments     Comment[]
   commentLikes CommentLike[]

--- a/src/app/(private)/(routes)/(member)/profile/components/location-input.tsx
+++ b/src/app/(private)/(routes)/(member)/profile/components/location-input.tsx
@@ -1,0 +1,134 @@
+import { Icons } from '@/components/icons'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@/components/ui/command'
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from '@/components/ui/form'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger
+} from '@/components/ui/popover'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { cn } from '@/lib/utils'
+import { Check, ChevronsUpDown } from 'lucide-react'
+import { useState } from 'react'
+import { useFormContext } from 'react-hook-form'
+import useLocationInput from './use-location-input'
+
+interface LocationInputProps {
+  isUpdating: boolean
+}
+
+const LocationInput = ({ isUpdating }: LocationInputProps) => {
+  const [open, setOpen] = useState(false)
+
+  const { control, watch } = useFormContext()
+  const { setInputValue, predictions, loadingPredictions } = useLocationInput()
+
+  const locationValue = watch('location')
+  const [value, setValue] = useState(locationValue)
+
+  return (
+    <FormField
+      control={control}
+      name="location"
+      disabled={isUpdating}
+      render={({ field }) => (
+        <FormItem className="flex flex-col">
+          <FormLabel>Location</FormLabel>
+          <FormControl>
+            <Popover open={open} onOpenChange={setOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  role="combobox"
+                  aria-expanded={open}
+                  className="w-full max-w-[500px] justify-between"
+                >
+                  <span className="truncate">
+                    {value && value !== '' ? value : 'Select your location'}
+                  </span>
+                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-[300px] p-0">
+                <Command>
+                  <CommandInput
+                    placeholder="Search location"
+                    onChangeCapture={e => {
+                      setInputValue(e.currentTarget.value)
+                    }}
+                  />
+                  <CommandList className="overflow-y-hidden py-1">
+                    <ScrollArea className="h-[150px] w-full pr-2">
+                      {loadingPredictions ? (
+                        <Icons.loader className="animate-spin duration-100 text-muted-foreground mx-auto mt-4 w-5 h-5" />
+                      ) : (
+                        <>
+                          <CommandEmpty>No location was found.</CommandEmpty>
+                          <CommandGroup>
+                            {!predictions?.length && (
+                              <CommandItem className="pointer-events-none justify-center">
+                                No locations was found.
+                              </CommandItem>
+                            )}
+                            {predictions?.length &&
+                              predictions?.map(location => (
+                                <CommandItem
+                                  key={location.value}
+                                  value={location.value}
+                                  onSelect={currentValue => {
+                                    setValue(
+                                      currentValue === location.value
+                                        ? ''
+                                        : location.value
+                                    )
+                                    field.onChange(
+                                      currentValue === location.value
+                                        ? ''
+                                        : location.value
+                                    )
+                                    setOpen(false)
+                                  }}
+                                  className="items-start"
+                                >
+                                  <Check
+                                    className={cn(
+                                      'mr-2 h-4 w-4',
+                                      value === location.value
+                                        ? 'opacity-100'
+                                        : 'opacity-0'
+                                    )}
+                                  />
+                                  {location.label}
+                                </CommandItem>
+                              ))}
+                          </CommandGroup>
+                        </>
+                      )}
+                    </ScrollArea>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+
+export default LocationInput

--- a/src/app/(private)/(routes)/(member)/profile/components/location-input.tsx
+++ b/src/app/(private)/(routes)/(member)/profile/components/location-input.tsx
@@ -20,8 +20,8 @@ import {
   PopoverContent,
   PopoverTrigger
 } from '@/components/ui/popover'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { cn } from '@/lib/utils'
+import { useElementSize } from '@mantine/hooks'
 import { Check, ChevronsUpDown } from 'lucide-react'
 import { useState } from 'react'
 import { useFormContext } from 'react-hook-form'
@@ -40,6 +40,8 @@ const LocationInput = ({ isUpdating }: LocationInputProps) => {
   const locationValue = watch('location')
   const [value, setValue] = useState(locationValue)
 
+  const { ref, width } = useElementSize()
+
   return (
     <FormField
       control={control}
@@ -52,6 +54,7 @@ const LocationInput = ({ isUpdating }: LocationInputProps) => {
             <Popover open={open} onOpenChange={setOpen}>
               <PopoverTrigger asChild>
                 <Button
+                  ref={ref}
                   variant="outline"
                   role="combobox"
                   aria-expanded={open}
@@ -63,7 +66,12 @@ const LocationInput = ({ isUpdating }: LocationInputProps) => {
                   <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                 </Button>
               </PopoverTrigger>
-              <PopoverContent className="w-[300px] p-0">
+              <PopoverContent
+                className="max-w-[500px] p-0"
+                style={{
+                  width: width + 'px'
+                }}
+              >
                 <Command>
                   <CommandInput
                     placeholder="Search location"
@@ -72,53 +80,51 @@ const LocationInput = ({ isUpdating }: LocationInputProps) => {
                     }}
                   />
                   <CommandList className="overflow-y-hidden py-1">
-                    <ScrollArea className="h-[150px] w-full pr-2">
-                      {loadingPredictions ? (
-                        <Icons.loader className="animate-spin duration-100 text-muted-foreground mx-auto mt-4 w-5 h-5" />
-                      ) : (
-                        <>
-                          <CommandEmpty>No location was found.</CommandEmpty>
-                          <CommandGroup>
-                            {!predictions?.length && (
-                              <CommandItem className="pointer-events-none justify-center">
-                                No locations was found.
+                    {loadingPredictions ? (
+                      <Icons.loader className="animate-spin duration-100 text-muted-foreground mx-auto my-4 w-5 h-5" />
+                    ) : (
+                      <>
+                        <CommandEmpty>No location was found.</CommandEmpty>
+                        <CommandGroup>
+                          {!predictions?.length && (
+                            <CommandItem className="pointer-events-none justify-center">
+                              No locations was found.
+                            </CommandItem>
+                          )}
+                          {predictions?.length &&
+                            predictions?.map(location => (
+                              <CommandItem
+                                key={location.value}
+                                value={location.value}
+                                onSelect={currentValue => {
+                                  setValue(
+                                    currentValue === location.value
+                                      ? ''
+                                      : location.value
+                                  )
+                                  field.onChange(
+                                    currentValue === location.value
+                                      ? ''
+                                      : location.value
+                                  )
+                                  setOpen(false)
+                                }}
+                                className="flex items-center gap-2"
+                              >
+                                <Check
+                                  className={cn(
+                                    'h-4 w-4 shrink-0',
+                                    value === location.value
+                                      ? 'opacity-100'
+                                      : 'opacity-0'
+                                  )}
+                                />
+                                <p className="truncate">{location.label}</p>
                               </CommandItem>
-                            )}
-                            {predictions?.length &&
-                              predictions?.map(location => (
-                                <CommandItem
-                                  key={location.value}
-                                  value={location.value}
-                                  onSelect={currentValue => {
-                                    setValue(
-                                      currentValue === location.value
-                                        ? ''
-                                        : location.value
-                                    )
-                                    field.onChange(
-                                      currentValue === location.value
-                                        ? ''
-                                        : location.value
-                                    )
-                                    setOpen(false)
-                                  }}
-                                  className="items-start"
-                                >
-                                  <Check
-                                    className={cn(
-                                      'mr-2 h-4 w-4',
-                                      value === location.value
-                                        ? 'opacity-100'
-                                        : 'opacity-0'
-                                    )}
-                                  />
-                                  {location.label}
-                                </CommandItem>
-                              ))}
-                          </CommandGroup>
-                        </>
-                      )}
-                    </ScrollArea>
+                            ))}
+                        </CommandGroup>
+                      </>
+                    )}
                   </CommandList>
                 </Command>
               </PopoverContent>

--- a/src/app/(private)/(routes)/(member)/profile/components/personal-info.tsx
+++ b/src/app/(private)/(routes)/(member)/profile/components/personal-info.tsx
@@ -25,6 +25,7 @@ import { isObjEmpty } from '@/lib/utils'
 import { useUser } from '@clerk/nextjs'
 import { type User } from '@prisma/client'
 import ImageInput from './image-input'
+import LocationInput from './location-input'
 import usePersonalInfo from './use-personal-info'
 
 export type PersonalInfoProps = {
@@ -221,6 +222,11 @@ export const PersonalInfo = ({ userProps }: PersonalInfoProps) => {
                     </FormItem>
                   )}
                 />
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-3 items-start gap-2 sm:gap-4 w-full">
+                <div className="sm:col-span-2">
+                  <LocationInput isUpdating={isUpdating} />
+                </div>
               </div>
               <div className="grid grid-cols-1 sm:grid-cols-3 items-start gap-2 sm:gap-4">
                 <FormField

--- a/src/app/(private)/(routes)/(member)/profile/components/use-location-input.ts
+++ b/src/app/(private)/(routes)/(member)/profile/components/use-location-input.ts
@@ -1,0 +1,50 @@
+import { useDebounceSearch } from '@/hooks/shared/use-debounce-search'
+import { useQuery } from '@tanstack/react-query'
+import { useMapsLibrary } from '@vis.gl/react-google-maps'
+
+const useLocationInput = () => {
+  const { searchTerm, setSearchTerm, debouncedSearchTerm } = useDebounceSearch({
+    initialValue: '',
+    onSearch: () => {}
+  })
+  const placesLib = useMapsLibrary('places')
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['places', debouncedSearchTerm, placesLib],
+    queryFn: async () => {
+      if (!placesLib || !debouncedSearchTerm) return
+      const autocompleteService = new placesLib.AutocompleteService()
+      const { predictions } = await autocompleteService.getPlacePredictions(
+        {
+          input: debouncedSearchTerm,
+          types: ['(cities)']
+        },
+        (predictions, status) => {
+          if (status === 'OK') {
+            return predictions
+          }
+        }
+      )
+
+      const mappedPredictions = predictions.map(prediction => {
+        return {
+          key: prediction.place_id,
+          label: prediction.description,
+          value: prediction.description
+        }
+      })
+
+      return mappedPredictions
+    },
+    enabled: !!placesLib && debouncedSearchTerm !== ''
+  })
+
+  return {
+    inputValue: searchTerm,
+    setInputValue: setSearchTerm,
+    predictions: data,
+    loadingPredictions: isLoading
+  }
+}
+
+export default useLocationInput

--- a/src/app/(private)/(routes)/(member)/profile/components/use-personal-info.ts
+++ b/src/app/(private)/(routes)/(member)/profile/components/use-personal-info.ts
@@ -64,7 +64,8 @@ export const personalInfoSchema = z
       .string()
       .min(8, { message: 'Password must be at least 8 characters long' })
       .optional(),
-    isPublicEmail: z.boolean().optional()
+    isPublicEmail: z.boolean().optional(),
+    location: z.string().optional()
   })
   .superRefine(({ passwordConfirmation, password, newPassword }, ctx) => {
     if (password && !passwordConfirmation) {
@@ -110,7 +111,8 @@ const usePersonalInfo = ({ userProps }: PersonalInfoProps) => {
         userProps.username ||
         (userProps.username === '' ? userProps.github ?? undefined : undefined),
       imageUrl: userProps.imageUrl ?? undefined,
-      isPublicEmail: userProps.isPublicEmail ?? false
+      isPublicEmail: userProps.isPublicEmail ?? false,
+      location: userProps.location ?? undefined
     },
     values: {
       userId: userProps.id ?? undefined,
@@ -123,7 +125,8 @@ const usePersonalInfo = ({ userProps }: PersonalInfoProps) => {
         userProps.username ||
         (userProps.username === '' ? userProps.github ?? '' : ''),
       imageUrl: userProps.imageUrl ?? undefined,
-      isPublicEmail: userProps.isPublicEmail ?? false
+      isPublicEmail: userProps.isPublicEmail ?? false,
+      location: userProps.location ?? undefined
     }
   })
 

--- a/src/app/(private)/(routes)/admin/users/[userId]/components/new-user-form/index.tsx
+++ b/src/app/(private)/(routes)/admin/users/[userId]/components/new-user-form/index.tsx
@@ -29,6 +29,7 @@ import { Roles } from '@/lib/types'
 import { type User } from '@prisma/client'
 import Image from 'next/image'
 import { useMemo } from 'react'
+import PositionSelect from './position-select'
 import { useNewUserForm } from './use-new-user-form'
 
 type NewUserFormProps = {
@@ -372,6 +373,7 @@ export const NewUserForm = ({ initialData }: NewUserFormProps) => {
                     </FormItem>
                   )}
                 />
+                <PositionSelect isPending={isPending} />
               </div>
             </div>
           </form>

--- a/src/app/(private)/(routes)/admin/users/[userId]/components/new-user-form/position-select.tsx
+++ b/src/app/(private)/(routes)/admin/users/[userId]/components/new-user-form/position-select.tsx
@@ -1,0 +1,73 @@
+import { Icons } from '@/components/icons'
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from '@/components/ui/form'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { Positions } from '@/lib/types'
+
+import { useFormContext } from 'react-hook-form'
+
+interface PositionSelectProps {
+  isPending: boolean
+}
+
+const PositionIconMap = {
+  AMBASSADOR: <Icons.award className="w-4 h-4 inline-flex" />,
+  BUILDER: <Icons.hammer className="w-4 h-4 inline-flex" />,
+  PSP: <Icons.globe className="w-4 h-4 inline-flex" />,
+  BASE: <Icons.book className="w-4 h-4 inline-flex" />,
+  ADMIN: <Icons.gear className="w-4 h-4 inline-flex" />
+}
+
+const PositionSelect = ({ isPending }: PositionSelectProps) => {
+  const { control } = useFormContext()
+  return (
+    <FormField
+      control={control}
+      name="position"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>Position</FormLabel>
+          {Positions && (
+            <Select
+              disabled={isPending}
+              onValueChange={field.onChange}
+              value={field.value}
+            >
+              <FormControl>
+                <SelectTrigger data-testid="role">
+                  <SelectValue placeholder="Select a position" />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                {Object.entries(Positions).map(([key, value]) => (
+                  <SelectItem
+                    key={key}
+                    value={key}
+                    className="flex gap-4 font-medium items-center"
+                  >
+                    {PositionIconMap[key as keyof typeof PositionIconMap]}{' '}
+                    {value}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+
+export default PositionSelect

--- a/src/app/(private)/(routes)/admin/users/[userId]/components/new-user-form/use-new-user-form.ts
+++ b/src/app/(private)/(routes)/admin/users/[userId]/components/new-user-form/use-new-user-form.ts
@@ -46,7 +46,8 @@ const formSchema = z.object({
   level: z.string(),
   github: z.string(),
   instagram: z.string(),
-  linkedin: z.string()
+  linkedin: z.string(),
+  position: z.enum(['AMBASSADOR', 'BUILDER', 'PSP', 'BASE', 'ADMIN'])
 })
 
 type NewUserFormValues = z.infer<typeof formSchema>
@@ -81,7 +82,8 @@ export const useNewUserForm = ({ initialData }: UseNewUserFormProps) => {
           level: initialData.level || '',
           github: initialData.github || '',
           linkedin: initialData.linkedin || '',
-          instagram: initialData.instagram || ''
+          instagram: initialData.instagram || '',
+          position: initialData.position || undefined
         }
       : {
           name: '',
@@ -91,7 +93,8 @@ export const useNewUserForm = ({ initialData }: UseNewUserFormProps) => {
           level: '',
           github: '',
           linkedin: '',
-          instagram: ''
+          instagram: '',
+          position: undefined
         }
   })
 

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -24,7 +24,8 @@ export async function PATCH(req: NextRequest) {
       passwordConfirmation,
       newPassword,
       imageUrl,
-      isPublicEmail
+      isPublicEmail,
+      location
     } = await req.json()
 
     if (!authUserId) return new NextResponse('Unauthenticated', { status: 401 })
@@ -108,7 +109,8 @@ export async function PATCH(req: NextRequest) {
         level,
         linkedin,
         role,
-        isPublicEmail
+        isPublicEmail,
+        location
       }
     })
 

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -25,7 +25,8 @@ export async function PATCH(req: NextRequest) {
       newPassword,
       imageUrl,
       isPublicEmail,
-      location
+      location,
+      position
     } = await req.json()
 
     if (!authUserId) return new NextResponse('Unauthenticated', { status: 401 })
@@ -110,7 +111,8 @@ export async function PATCH(req: NextRequest) {
         linkedin,
         role,
         isPublicEmail,
-        location
+        location,
+        position
       }
     })
 

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -77,7 +77,11 @@ import {
   Save,
   GripVertical,
   UserX,
-  UserCheck
+  UserCheck,
+  Award,
+  Hammer,
+  BookText,
+  Settings
 } from 'lucide-react'
 
 export type IconType = LucideIcon
@@ -161,5 +165,9 @@ export const Icons = {
   dot: Dot,
   save: Save,
   userX: UserX,
-  userCheck: UserCheck
+  userCheck: UserCheck,
+  award: Award,
+  hammer: Hammer,
+  book: BookText,
+  gear: Settings
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -35,6 +35,14 @@ export enum Roles {
   Admin = 'Admin'
 }
 
+export enum Positions {
+  BASE = 'Base',
+  PSP = 'PSP',
+  BUILDER = 'Builder',
+  AMBASSADOR = 'Ambassador',
+  ADMIN = 'Admin'
+}
+
 export type ExtendedPost = Post & {
   category: Category
   likes: Like[]

--- a/src/providers/app-provider.tsx
+++ b/src/providers/app-provider.tsx
@@ -3,6 +3,7 @@
 import { Toaster } from '@/components/ui/toaster'
 import { ModalProvider } from '@/providers/modal-providers'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { APIProvider } from '@vis.gl/react-google-maps'
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
 import { type ThemeProviderProps } from 'next-themes/dist/types'
 
@@ -21,18 +22,23 @@ const AppProviders = ({ children }: Props) => {
   })
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider
-        attribute="class"
-        defaultTheme="dark"
-        enableSystem
-        disableTransitionOnChange
-      >
-        <ModalProvider />
-        <Toaster />
-        {children}
-      </ThemeProvider>
-    </QueryClientProvider>
+    <APIProvider
+      apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!}
+      version="beta"
+    >
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="dark"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <ModalProvider />
+          <Toaster />
+          {children}
+        </ThemeProvider>
+      </QueryClientProvider>
+    </APIProvider>
   )
 }
 


### PR DESCRIPTION
## Description
This PR adds 2 new properties to the user schema ("location" and "position"), and a new location select component at the user profile that uses Google Maps Places API, in order to produce normalized locations. It also adds the position selector at the user update page (admin).

## What type of PR is this?
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 📦 Chore
- [ ] ⏩ Revert

## Screenshots:
- Location selector (user profile):
![CleanShot 2024-11-12 at 10 06 08@2x](https://github.com/user-attachments/assets/187a0143-5a99-4079-acb6-df3ed7e2ad84)
![CleanShot 2024-11-12 at 10 07 22@2x](https://github.com/user-attachments/assets/02b11581-f234-4a44-92fd-db1749bd2563)
- Position selector (user update - admin):
![CleanShot 2024-11-12 at 10 08 24@2x](https://github.com/user-attachments/assets/1908ed8e-acd0-4bf4-b54e-a45c150b0f30)
![CleanShot 2024-11-12 at 10 08 48@2x](https://github.com/user-attachments/assets/9be20dcd-2c8a-45c2-8f15-bf76bf026f0e)
