### PR TITLE
Fix: mentorship modules UI

### DIFF
--- a/src/app/(private)/(routes)/(member)/mentorship/components/module-carousel/index.tsx
+++ b/src/app/(private)/(routes)/(member)/mentorship/components/module-carousel/index.tsx
@@ -12,6 +12,7 @@ import {
 import { toast } from '@/components/ui/use-toast'
 import { appRoutes } from '@/lib/constants'
 import { cn } from '@/lib/utils'
+import { useViewportSize } from '@mantine/hooks'
 import { type Video } from '@prisma/client'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -40,6 +41,7 @@ export const ModuleCarousel = ({
     handleClickBackward,
     handleClickForward
   } = useModuleCarousel()
+  const { width } = useViewportSize()
 
   if (!isMounted) return <SkeletonMentorshipPage />
 
@@ -67,7 +69,7 @@ export const ModuleCarousel = ({
         setApi={setCarouselApi}
         className="w-full overflow-x-hidden"
         opts={{
-          slidesToScroll: 2
+          slidesToScroll: width > 768 ? 2 : 1
         }}
       >
         <CarouselContent>
@@ -85,7 +87,7 @@ export const ModuleCarousel = ({
                   className={cn(
                     !hasPermissionCombinated &&
                       'flex flex-col justify-center items-center relative',
-                    'xl:basis-1/4 md:basis-1/3 basis-1/2 cursor-pointer',
+                    'xl:basis-1/4 md:basis-1/3 basis-full min-[480px]:basis-1/2  cursor-pointer',
                     'transition-transform ease-in-out hover:scale-110 hover:-translate-y-1 duration-300 min-h-[300px]'
                   )}
                   onClick={() => {
@@ -122,7 +124,7 @@ export const ModuleCarousel = ({
             return (
               <CarouselItem
                 key={module.id}
-                className="group xl:basis-1/4 md:basis-1/3 basis-1/2 cursor-pointer transition-transform ease-in-out hover:scale-110 hover:-translate-y-1 duration-300 min-h-[300px]"
+                className="group xl:basis-1/4 md:basis-1/3 basis-full min-[480px]:basis-1/2 cursor-pointer transition-transform ease-in-out hover:scale-110 hover:-translate-y-1 duration-300 min-h-[300px]"
               >
                 <Link
                   className={`${


### PR DESCRIPTION
## Description
This PR adjusts the responsive UI of the mentorship carousel modules components, initiating the displayed modules with only 1, and then expanding to 2 and beyond as the viewport expands.

## What type of PR is this?
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 📦 Chore
- [ ] ⏩ Revert

## Screenshots:
- Mobile (small): ![CleanShot 2024-12-08 at 23 20 21@2x](https://github.com/user-attachments/assets/b8c430a7-7243-4755-ad82-f7d525754a0f)
- Mobile (large): ![CleanShot 2024-12-08 at 23 20 40@2x](https://github.com/user-attachments/assets/06394ce5-626c-4d69-b83f-f585466d446b)
- Desktop: ![CleanShot 2024-12-08 at 23 21 00@2x](https://github.com/user-attachments/assets/87906c6d-b1bc-41f0-9d48-a66515e38883)
