### PR TITLE
Fix: adding sort-by to public-notes-card query

### DIFF
--- a/src/app/(private)/(routes)/(member)/dashboard/components/public-notes-card.tsx
+++ b/src/app/(private)/(routes)/(member)/dashboard/components/public-notes-card.tsx
@@ -6,15 +6,18 @@ import {
   CardHeader,
   CardTitle
 } from '@/components/ui/card'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import prismadb from '@/lib/prismadb'
 import { Suspense } from 'react'
 import { TimelineNotes } from './timeline-notes'
-import { ScrollArea } from '@/components/ui/scroll-area'
 
 export const PublicNotesCard = async () => {
   const notes = await prismadb.note.findMany({
     where: {
       isPublic: true
+    },
+    orderBy: {
+      createdAt: 'desc'
     },
     take: 10
   })


### PR DESCRIPTION
## Description
This PR fixes the ordering of the code-up challenge public notes on the dashboard. Previously it had no explicit ordering and a `desc` ordering was applied, always displaying the latest public notes.

## What type of PR is this?
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 📦 Chore
- [ ] ⏩ Revert

## Screenshots:
![CleanShot 2025-01-08 at 15 59 37@2x](https://github.com/user-attachments/assets/56ae4f9d-1bd7-4bca-b1e5-02d6ceb6b562)
