### PR TITLE
Fix: fixing apperance-form missing default values prop

### DIFF
--- a/src/app/(private)/(routes)/(member)/profile/appearance/components/appearance-form.tsx
+++ b/src/app/(private)/(routes)/(member)/profile/appearance/components/appearance-form.tsx
@@ -27,10 +27,13 @@ const appearanceFormSchema = z.object({
 type AppearanceFormValues = z.infer<typeof appearanceFormSchema>
 
 export const AppearanceForm = () => {
-  const { setTheme } = useTheme()
+  const { setTheme, theme } = useTheme()
 
   const form = useForm<AppearanceFormValues>({
-    resolver: zodResolver(appearanceFormSchema)
+    resolver: zodResolver(appearanceFormSchema),
+    defaultValues: {
+      theme: theme as AppearanceFormValues['theme']
+    }
   })
 
   function onSubmit(data: AppearanceFormValues) {
@@ -90,7 +93,7 @@ export const AppearanceForm = () => {
                     <FormControl>
                       <RadioGroupItem value="dark" className="sr-only" />
                     </FormControl>
-                    <div className="items-center rounded-md border-2 border-muted bg-popover p-1 hover:bg-accent hover:text-accent-foreground">
+                    <div className="items-center rounded-md border-2 border-muted p-1 hover:border-accent">
                       <div className="space-y-2 rounded-sm bg-slate-950 p-2">
                         <div className="space-y-2 rounded-md bg-slate-800 p-2 shadow-sm">
                           <div className="h-2 max-w-[80px] rounded-lg bg-slate-400" />
@@ -116,7 +119,7 @@ export const AppearanceForm = () => {
                     <FormControl>
                       <RadioGroupItem value="system" className="sr-only" />
                     </FormControl>
-                    <div className="items-center rounded-md border-2 border-muted bg-popover p-1 hover:border-accent">
+                    <div className="items-center rounded-md border-2 border-muted p-1 hover:border-accent">
                       <div className="space-y-2 rounded-sm bg-[#ecedef] p-2">
                         <div className="space-y-2 rounded-md bg-slate-800 p-2 shadow-sm">
                           <div className="h-2 max-w-[80px] rounded-lg bg-slate-400" />


### PR DESCRIPTION
## Description
This PR fixes the default value for the appearance form, at the user profile. Without the default value, the selector did not show the selected theme, until user selected it again.

## What type of PR is this?
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 📦 Chore
- [ ] ⏩ Revert

## Screenshots
![CleanShot 2025-02-12 at 12 07 27@2x](https://github.com/user-attachments/assets/f3bc6139-4ad5-4ec6-a05d-0838241bed3a)
![CleanShot 2025-02-12 at 12 07 41@2x](https://github.com/user-attachments/assets/91c3306e-a99a-4831-b64d-0e5c96a8882d)

