### PR TITLE
Fix codeUp `orderBy` notes to ensure correct sequence

### DIFF
--- a/src/app/(private)/(routes)/(member)/code-up/components/code-up-content.tsx
+++ b/src/app/(private)/(routes)/(member)/code-up/components/code-up-content.tsx
@@ -17,6 +17,9 @@ export const CodeUpContent = async () => {
   const notes = await prismadb.note.findMany({
     where: {
       userId: user.id
+    },
+    orderBy: {
+      createdAt: 'asc'
     }
   })
 

--- a/src/app/api/note/route.ts
+++ b/src/app/api/note/route.ts
@@ -8,9 +8,12 @@ export async function POST(req: NextRequest) {
 
     if (!userId) return new NextResponse('Unauthenticated', { status: 401 })
 
+    const totalNotes = await prismadb.note.count()
+    const defaultTitle = `${totalNotes + 1} - Untitled`
+
     const note = await prismadb.note.create({
       data: {
-        title: 'Untitled',
+        title: defaultTitle,
         userId
       }
     })


### PR DESCRIPTION
## Context
While documenting my days on codeUp, I noticed that notes were not being displayed in the correct sequence (ordered by createdAt).

Additionally, I updated the default note title from `Untitled` to `${count + 1} - Untitled`, ensuring that new notes are created with a sequential number in the title for better organization.

## Done
- Fixed the ordering of notes by sorting them based on `createdAt`.
- Updated the default note title to include its sequential number (`${count + 1} - Untitled`).
- Improved note organization and readability in `codeUp`.

## Preview (Before)

[Gravação de tela de 15-02-2025 11:31:05.webm](https://github.com/user-attachments/assets/e92dacbd-c7bc-433a-85a8-96e5fefe449f)


## Preview (After)

[Gravação de tela de 15-02-2025 11:45:14.webm](https://github.com/user-attachments/assets/4c8028e2-ab6d-4b59-88d5-39fca1d3b3fb)

## OBS:
- The `sequential numbering in note titles` is an enhancement I believe improves organization. However, if you feel this is unnecessary, I can remove it and keep only the `orderBy` fix.

