### PR TITLE
Search Dialog - Hide helper text if is mobile

### DIFF
--- a/src/components/top-bar/search-dialog/empty-state.tsx
+++ b/src/components/top-bar/search-dialog/empty-state.tsx
@@ -11,7 +11,7 @@ export const EmptyState = () => (
         posts and users.
       </h6>
     </div>
-    <div className="flex flex-wrap items-center border-t bg-gray-50 px-4 py-2.5 text-xs text-gray-800 dark:bg-card dark:text-gray-100">
+    <div className="hidden sm:flex flex-wrap items-center border-t bg-gray-50 px-4 py-2.5 text-xs text-gray-800 dark:bg-card dark:text-gray-100">
       <span className="mr-1">Press</span>
       <kbd className="pointer-events-none hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex">
         esc


### PR DESCRIPTION
# Description

This pull request enhances the user experience by updating the helper text displayed in the search dialog's empty state, providing clearer guidance to users.

## Changes Made
- **Helper Text Update**: The helper text shown when the search dialog is empty has been revised to offer more informative and user-friendly guidance.

## Benefits
- Improved user guidance in the search dialog's empty state.
- Enhanced clarity and usability for users interacting with the search feature.

## Preview

### Before

![before-search-dialog-empty-state-helper-text](https://github.com/user-attachments/assets/3e2395f7-7ed1-45fe-af51-beb732078639)

### After 

![after-search-dialog-empty-state-helper-text](https://github.com/user-attachments/assets/8f0bd4b1-a8ec-47a6-9c51-9f59af8f3608)


