### PR TITLE
fix: Cannot read properties of null (reading 'modules')

### DIFF
--- a/src/app/(private)/(routes)/admin/classroom/(routes)/[classroomId]/components/new-classroom-form/use-new-classroom-form.ts
+++ b/src/app/(private)/(routes)/admin/classroom/(routes)/[classroomId]/components/new-classroom-form/use-new-classroom-form.ts
@@ -170,7 +170,7 @@ export const useNewClassroomForm = ({
   const { Admin, Builder, ...roles } = Roles
 
   useEffect(() => {
-    if (classroomData?.data.modules)
+    if (classroomData?.data?.modules)
       setClassroomModules(classroomData.data.modules)
   }, [classroomData])
 


### PR DESCRIPTION
- Fix error creating new classroom