### PR TITLE
Adjusts `totalNotes` count to count only notes related to the user

### DIFF
--- a/src/app/api/note/route.ts
+++ b/src/app/api/note/route.ts
@@ -8,8 +8,8 @@ export async function POST(req: NextRequest) {
 
     if (!userId) return new NextResponse('Unauthenticated', { status: 401 })
 
-    const totalNotes = await prismadb.note.count()
-    const defaultTitle = `${totalNotes + 1} - Untitled`
+    const userNotesCount = await prismadb.note.count({ where: { userId } })
+    const defaultTitle = `${userNotesCount + 1} - Untitled`
 
     const note = await prismadb.note.create({
       data: {


### PR DESCRIPTION
- When creating a new note, it was counting the `total notes` to create the title with `count + 1`. But this count was wrong, as it was not considering only the user's notes.

## Bug preview:

[Gravação de tela de 23-02-2025 18:59:04.webm](https://github.com/user-attachments/assets/eea973e5-993c-42ba-b426-9a7f5925a3f2)

## OBS
- PR that implemented `total notes count`: #181 