### PR TITLE
Refactor/remove obsolete roles

### DIFF
--- a/cypress/e2e/admin-users.cy.ts
+++ b/cypress/e2e/admin-users.cy.ts
@@ -49,7 +49,6 @@ describe('Admin Users page', () => {
     cy.get('[data-testid="instagram"]').type('@johndoe') // instagram
     cy.get('[data-testid="role"]').click() // roles
     cy.get('[data-testid="Admin"]').click()
-    cy.get('[data-testid="Builder"]').click()
     cy.get('[data-testid="submit"]').click({ force: true })
     cy.contains('Success')
     cy.contains('User created successfully')

--- a/prisma/migrations/20250225133419_removing_obsolete_roles/migration.sql
+++ b/prisma/migrations/20250225133419_removing_obsolete_roles/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - The values [PerfilFechado,PortifolioBoostProgram,Builder] on the enum `Roles` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "Roles_new" AS ENUM ('PrePsp', 'Base', 'ProgramadorSemPatria', 'Prime', 'Admin');
+ALTER TABLE "Classroom" ALTER COLUMN "permissions" DROP DEFAULT;
+ALTER TABLE "User" ALTER COLUMN "role" DROP DEFAULT;
+ALTER TABLE "User" ALTER COLUMN "role" TYPE "Roles_new"[] USING ("role"::text::"Roles_new"[]);
+ALTER TABLE "Classroom" ALTER COLUMN "permissions" TYPE "Roles_new"[] USING ("permissions"::text::"Roles_new"[]);
+ALTER TYPE "Roles" RENAME TO "Roles_old";
+ALTER TYPE "Roles_new" RENAME TO "Roles";
+DROP TYPE "Roles_old";
+ALTER TABLE "Classroom" ALTER COLUMN "permissions" SET DEFAULT ARRAY[]::"Roles"[];
+ALTER TABLE "User" ALTER COLUMN "role" SET DEFAULT ARRAY[]::"Roles"[];
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -205,12 +205,9 @@ model CommentLike {
 
 enum Roles {
   PrePsp
-  PerfilFechado
-  PortifolioBoostProgram
   Base
   ProgramadorSemPatria
   Prime
-  Builder
   Admin
 }
 

--- a/src/app/(private)/(routes)/admin/classroom/(routes)/[classroomId]/components/new-classroom-form/use-new-classroom-form.ts
+++ b/src/app/(private)/(routes)/admin/classroom/(routes)/[classroomId]/components/new-classroom-form/use-new-classroom-form.ts
@@ -167,7 +167,7 @@ export const useNewClassroomForm = ({
     }
   }
 
-  const { Admin, Builder, ...roles } = Roles
+  const { Admin, ...roles } = Roles
 
   useEffect(() => {
     if (classroomData?.data?.modules)

--- a/src/app/(private)/(routes)/admin/layout.tsx
+++ b/src/app/(private)/(routes)/admin/layout.tsx
@@ -17,8 +17,7 @@ export default async function AdminLayout({
     }
   })
 
-  if (!user?.role.includes(Roles.Admin) && !user?.role.includes(Roles.Builder))
-    return redirect(appRoutes.dashboard)
+  if (!user?.role.includes(Roles.Admin)) return redirect(appRoutes.dashboard)
 
   return <>{children}</>
 }

--- a/src/app/(private)/(routes)/admin/users/[userId]/components/new-user-form/use-new-user-form.ts
+++ b/src/app/(private)/(routes)/admin/users/[userId]/components/new-user-form/use-new-user-form.ts
@@ -67,27 +67,27 @@ export const useNewUserForm = ({ initialData }: UseNewUserFormProps) => {
     resolver: zodResolver(formSchema),
     defaultValues: initialData
       ? {
-        name: initialData.name || '',
-        username: initialData.username || '',
-        email: initialData.email || '',
-        role: initialData.role || [],
-        level: initialData.level || '',
-        github: initialData.github || '',
-        linkedin: initialData.linkedin || '',
-        instagram: initialData.instagram || '',
-        position: initialData.position || undefined
-      }
+          name: initialData.name || '',
+          username: initialData.username || '',
+          email: initialData.email || '',
+          role: initialData.role || [],
+          level: initialData.level || '',
+          github: initialData.github || '',
+          linkedin: initialData.linkedin || '',
+          instagram: initialData.instagram || '',
+          position: initialData.position || undefined
+        }
       : {
-        name: '',
-        username: '',
-        email: '',
-        role: [],
-        level: '',
-        github: '',
-        linkedin: '',
-        instagram: '',
-        position: undefined
-      }
+          name: '',
+          username: '',
+          email: '',
+          role: [],
+          level: '',
+          github: '',
+          linkedin: '',
+          instagram: '',
+          position: undefined
+        }
   })
 
   const { mutateAsync: deleteUser, isPending: isDeletingUser } = useMutation({

--- a/src/app/(private)/(routes)/admin/users/[userId]/components/new-user-form/use-new-user-form.ts
+++ b/src/app/(private)/(routes)/admin/users/[userId]/components/new-user-form/use-new-user-form.ts
@@ -33,16 +33,7 @@ const formSchema = z.object({
       message: 'Email is required'
     }),
   role: z.array(
-    z.enum([
-      'PrePsp',
-      'PerfilFechado',
-      'PortifolioBoostProgram',
-      'Base',
-      'ProgramadorSemPatria',
-      'Prime',
-      'Builder',
-      'Admin'
-    ])
+    z.enum(['PrePsp', 'Base', 'ProgramadorSemPatria', 'Prime', 'Admin'])
   ),
   level: z.string(),
   github: z.string(),
@@ -76,27 +67,27 @@ export const useNewUserForm = ({ initialData }: UseNewUserFormProps) => {
     resolver: zodResolver(formSchema),
     defaultValues: initialData
       ? {
-          name: initialData.name || '',
-          username: initialData.username || '',
-          email: initialData.email || '',
-          role: initialData.role || [],
-          level: initialData.level || '',
-          github: initialData.github || '',
-          linkedin: initialData.linkedin || '',
-          instagram: initialData.instagram || '',
-          position: initialData.position || undefined
-        }
+        name: initialData.name || '',
+        username: initialData.username || '',
+        email: initialData.email || '',
+        role: initialData.role || [],
+        level: initialData.level || '',
+        github: initialData.github || '',
+        linkedin: initialData.linkedin || '',
+        instagram: initialData.instagram || '',
+        position: initialData.position || undefined
+      }
       : {
-          name: '',
-          username: '',
-          email: '',
-          role: [],
-          level: '',
-          github: '',
-          linkedin: '',
-          instagram: '',
-          position: undefined
-        }
+        name: '',
+        username: '',
+        email: '',
+        role: [],
+        level: '',
+        github: '',
+        linkedin: '',
+        instagram: '',
+        position: undefined
+      }
   })
 
   const { mutateAsync: deleteUser, isPending: isDeletingUser } = useMutation({

--- a/src/infra/scripts/seed.ts
+++ b/src/infra/scripts/seed.ts
@@ -87,7 +87,7 @@ async function seed() {
       password: process.env.ADMIN_SEM_PATRIA_PASSWORD ?? '',
       name: process.env.ADMIN_SEM_PATRIA_NAME ?? '',
       username: process.env.ADMIN_SEM_PATRIA_USERNAME ?? '',
-      role: ['Admin', 'Builder']
+      role: ['Admin']
     }
   ]
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -12,14 +12,6 @@ export const permissions: Record<UserAbilityRoles, PermissionsByRole> = {
   ADMIN: (_, { can }) => {
     can('manage', 'all')
   },
-  BUILDER: (_, { can }) => {
-    can(
-      'get',
-      ['Category', 'Classroom', 'Course', 'Event', 'User', 'Interest'],
-      {}
-    )
-    can('get', 'CMS')
-  },
   MEMBER: (user, { can }) => {
     can('delete', 'Post', { userId: { equals: user.id } })
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -27,12 +27,9 @@ export type MentorshipProgramModuleProps = {
 
 export enum Roles {
   PrePsp = 'Pre PSP',
-  PerfilFechado = 'Perfil Fechado',
-  PortifolioBoostProgram = 'Portifólio Boost Program',
   Base = 'Base',
   ProgramadorSemPatria = 'Programador Sem Pátria',
   Prime = 'Prime',
-  Builder = 'Builder',
   Admin = 'Admin'
 }
 
@@ -55,4 +52,4 @@ export type VideoWithAttachments = Video & {
   attachments: Attachment[]
 }
 
-export type UserAbilityRoles = 'ADMIN' | 'BUILDER' | 'MEMBER'
+export type UserAbilityRoles = 'ADMIN' | 'MEMBER'

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -59,7 +59,6 @@ export const formatTitle = (title: string) => {
     'a-base': 'A Base',
     psp: 'Programador Sem Pátria',
     prime: 'Programador Prime',
-    'perfil-fechado': 'Perfil Fechado'
   }
 
   return titleHref[title]
@@ -90,10 +89,8 @@ export const getStringFromDate = (date: string) => {
 
 export const defineUserRole = (user: User): UserAbilityRoles => {
   const hasAdmin = user.role.some(role => role === Roles.Admin)
-  const hasBuilder = user.role.some(role => role === Roles.Builder)
 
   if (hasAdmin) return 'ADMIN'
-  if (hasBuilder) return 'BUILDER'
   return 'MEMBER'
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -58,7 +58,7 @@ export const formatTitle = (title: string) => {
   const titleHref: Record<string, string> = {
     'a-base': 'A Base',
     psp: 'Programador Sem Pátria',
-    prime: 'Programador Prime',
+    prime: 'Programador Prime'
   }
 
   return titleHref[title]


### PR DESCRIPTION
## Description
This PR removes the _PortfolioBoostProgram_, _PerfilFechado_, and _Builder_  obsolete roles referenced in the code. Removing these obsolete roles from the database references should be made by a local script **before sending to production**, to audit and migrate these roles, like what was done in development mode.

## What type of PR is this?
- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 📦 Chore
- [ ] ⏩ Revert
