### PR TITLE
Adjust course card image and Fix Hydration UI Error

### DIFF
--- a/src/app/(private)/(routes)/(member)/courses/components/course-card.tsx
+++ b/src/app/(private)/(routes)/(member)/courses/components/course-card.tsx
@@ -7,13 +7,13 @@ import {
   IconCourseBeginnerLevel,
   IconCourseIntermediateLevel
 } from '@/components/icons/custom-svgs'
+import { Badge } from '@/components/ui/badge'
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger
 } from '@/components/ui/tooltip'
-import { cn } from '@/lib/utils'
 import { type Course } from '@prisma/client'
 import Image, { type StaticImageData } from 'next/image'
 import { useMemo } from 'react'
@@ -29,7 +29,7 @@ export const CourseCard = ({ courseProps: props }: CourseCardProps) => {
       intermediate: IntermediateImg,
       advanced: AdvancedImg
     }
-    return levelImage[level]
+    return levelImage[level] || BeginnerImg
   }
 
   const loadCourseIconLevel = useMemo(() => {
@@ -44,28 +44,23 @@ export const CourseCard = ({ courseProps: props }: CourseCardProps) => {
 
   return (
     <div className="relative flex w-full">
-      <div className="flex flex-col w-full justify-start rounded-[10px] overflow-hidden transition cursor-pointer text-left  border bg-card hover:bg-card/20">
-        <Image alt="bg-card" src={BgCardImg} className="absolute" />
+      <div className="flex flex-col w-full justify-start rounded-[10px] overflow-hidden transition cursor-pointer text-left border bg-card hover:bg-card/20">
+        <Image alt="bg-course-card" src={BgCardImg} className="absolute" />
         <div className="flex flex-col flex-1 w-full gap-4 p-6">
           <div className="w-full flex items-center justify-between h-11 mb-1">
-            <div className="relative w-18 h-16">
+            <div className="relative">
               <Image
                 src={renderLevelImage(props.level)}
                 alt={props.name}
                 className="w-full h-full rounded-md object-cover"
+                width={72}
+                height={64}
               />
             </div>
             <div className="flex gap-2 items-center self-start shrink-0">
-              <span
-                className={cn(
-                  props.isPaid
-                    ? 'text-violet-900 border-violet-800'
-                    : 'text-brand-green-600 border-brand-green-600',
-                  'inline-flex justify-center items-center gap-1 flex-shrink-0 w-fit rounded font-bold uppercase box-border  h-6 px-2 text-[10px] leading-4 bg-transparent border border-solid'
-                )}
-              >
+              <Badge variant={props.isPaid ? 'default' : 'secondary'}>
                 {props.isPaid ? 'PAID' : 'FREE'}
-              </span>
+              </Badge>
             </div>
           </div>
           <div>

--- a/src/app/(private)/(routes)/(member)/courses/components/courses-content.tsx
+++ b/src/app/(private)/(routes)/(member)/courses/components/courses-content.tsx
@@ -51,7 +51,7 @@ const CoursesContent = ({ categories }: CoursesContentProps) => {
         ))}
       </div>
 
-      <div className="lg:grid lg:grid-cols-[1fr_280px] items-start lg:gap-8 gap-6 mt-2">
+      <div className="lg:grid lg:grid-cols-[1fr_280px] items-start lg:gap-8 gap-6 mt-6">
         <div className="flex flex-col gap-8">
           {isLoading && <SkeletonCourseCards />}
           <div className="flex flex-col gap-8">

--- a/src/app/(private)/(routes)/(member)/courses/page.tsx
+++ b/src/app/(private)/(routes)/(member)/courses/page.tsx
@@ -31,14 +31,12 @@ const CoursesPage = async () => {
   )
 
   return (
-    <>
-      <DefaultLayout>
-        <Header title="Courses" />
-        <Suspense fallback={<SkeletonCoursePage />}>
-          <CoursesContent categories={categoriesWithCourses} />
-        </Suspense>
-      </DefaultLayout>
-    </>
+    <DefaultLayout>
+      <Header title="Courses" />
+      <Suspense fallback={<SkeletonCoursePage />}>
+        <CoursesContent categories={categoriesWithCourses} />
+      </Suspense>
+    </DefaultLayout>
   )
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { Analytics } from '@vercel/analytics/react'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import '../styles/globals.css'
+import { type ReactNode } from 'react'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -23,18 +24,14 @@ export const metadata: Metadata = {
   }
 }
 
-export default function RootLayout({
-  children
-}: {
-  children: React.ReactNode
-}) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <ClerkProvider
-      appearance={{
-        baseTheme: dark
-      }}
-    >
-      <html lang="en">
+    <html lang="en">
+      <ClerkProvider
+        appearance={{
+          baseTheme: dark
+        }}
+      >
         <body
           className={cn(
             'min-h-screen bg-background font-sans antialiased',
@@ -46,7 +43,7 @@ export default function RootLayout({
             <Analytics mode="auto" />
           </AppProviders>
         </body>
-      </html>
-    </ClerkProvider>
+      </ClerkProvider>
+    </html>
   )
 }

--- a/src/components/top-bar/index.tsx
+++ b/src/components/top-bar/index.tsx
@@ -19,23 +19,28 @@ const feedbackLink =
 const TopBar = () => {
   const { isMobile } = useIsMobile()
   const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const [isMounted, setIsMounted] = useState(false)
 
   const isMac =
     typeof window !== 'undefined' &&
     window.navigator.userAgent.toLowerCase().includes('mac')
 
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault()
-        setIsSearchOpen(prev => !prev)
-      }
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      setIsSearchOpen(prev => !prev)
     }
+  }
+
+  useEffect(() => {
+    setIsMounted(true)
     document.addEventListener('keydown', handleKeyDown)
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
     }
   }, [])
+
+  if (!isMounted) return null
 
   return (
     <>


### PR DESCRIPTION
##  Changes Made

Course Content:
- Default image to beginner if no `src` or `level` is found
- Use badge component instead of `span` according to project's color palette
- Applied higher margin top

Layout:
- Reorganize modules declaration according to this [reference](https://github.com/clerk/nextjs-auth-starter-template/blob/main/app/layout.tsx#L31).
  - The `ClerkProvider` should be encompassed by an `html` tag.
- Fixed hydration UI error on development mode. [Reference](https://dev.to/keremcanseker/there-was-an-error-while-hydrating-this-suspense-boundary-switched-to-client-rendering-nextjs-14-me7).

## Preview

Tested on:
- Safari Version 18.3 (20620.2.4.11.5)
- Google Chrome Version 134.0.6998.89 (Official Build) (arm64)

### Before

<img width="1840" alt="before-fix-course-card-image" src="https://github.com/user-attachments/assets/fd21e07c-6972-4d08-a72d-20a1855139a4" />

### After

<img width="1840" alt="after-fix-course-card-image" src="https://github.com/user-attachments/assets/d8b9006e-669a-422b-a65d-0d97c27d300c" />
