### PR TITLE
[`feat`]: Creates visualization of `followed` and `following` users

### DIFF
--- a/src/app/(private)/(routes)/(member)/user/[userName]/components/FollowersAndFollowingModal.tsx
+++ b/src/app/(private)/(routes)/(member)/user/[userName]/components/FollowersAndFollowingModal.tsx
@@ -1,0 +1,60 @@
+import avatarImg from '@/assets/avatar.png'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from '@/components/ui/dialog'
+import Image from 'next/image'
+import Link from 'next/link'
+import { type ReactNode } from 'react'
+import { type Followers, type Followings } from './useFollowersAndFollowings'
+
+type FollowersAndFollowingModalProps = {
+  children: ReactNode
+  title: string
+  followersOrFollowing: Followers | Followings
+}
+
+export const FollowersAndFollowingModal = ({
+  children,
+  title,
+  followersOrFollowing
+}: FollowersAndFollowingModalProps) => {
+  return (
+    <Dialog>
+      <DialogTrigger>{children}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <ul className="flex flex-col gap-2 max-h-[500px] overflow-y-auto">
+          {followersOrFollowing?.map(user => (
+            <li id={user.id} key={user.id}>
+              <Link
+                href={`/user/${user.username}`}
+                className="flex gap-2 items-center group rounded-md py-2 hover:bg-muted transition-all"
+              >
+                <Avatar className="ml-4">
+                  <AvatarImage src={user.imageUrl || ''} />
+                  <AvatarFallback>
+                    <Image
+                      src={avatarImg.src}
+                      alt="avatar"
+                      width={40}
+                      height={40}
+                    />
+                  </AvatarFallback>
+                </Avatar>
+
+                <span>@{user.username}</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/app/(private)/(routes)/(member)/user/[userName]/components/Header.tsx
+++ b/src/app/(private)/(routes)/(member)/user/[userName]/components/Header.tsx
@@ -1,17 +1,19 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { Icons } from '@/components/icons'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { type User } from '@prisma/client'
-import { type User as ClerkUser } from '@clerk/nextjs/server'
-import { useFollowersAndFollowings } from './useFollowersAndFollowings'
-import { Roles, Positions } from '@/lib/types'
-import { TRAIL_LABELS, PositionIconMap } from '@/lib/constants'
+import { PositionIconMap, TRAIL_LABELS } from '@/lib/constants'
+import { Positions, Roles } from '@/lib/types'
 import { getHighestPriorityRole } from '@/lib/utils'
-import { Icons } from '@/components/icons'
+import { type User as ClerkUser } from '@clerk/nextjs/server'
+import { type User } from '@prisma/client'
+import { useFollowersAndFollowings } from './useFollowersAndFollowings'
 
+import { useEffect, useState } from 'react'
+
+import { FollowersAndFollowingModal } from './FollowersAndFollowingModal'
 const Header = ({
   user,
   currentUser
@@ -19,7 +21,7 @@ const Header = ({
   user: User
   currentUser: ClerkUser
 }) => {
-  const { follow, followers, unfollow, following, unfollowing } =
+  const { follow, followers, unfollow, following, unfollowing, followedUsers } =
     useFollowersAndFollowings(user.id)
   const [isFollowed, setIsFollowed] = useState(false)
 
@@ -95,8 +97,19 @@ const Header = ({
         </div>
       </div>
       <div className="grid grid-cols-2 gap-6 text-center md:grid-cols-2">
-        <Stat label="Followers" value={followers.length} />
-        <Stat label="Following" value={user.followings} />
+        <FollowersAndFollowingModal
+          title="Followers"
+          followersOrFollowing={followers}
+        >
+          <Stat label="Followers" value={followers.length} />
+        </FollowersAndFollowingModal>
+
+        <FollowersAndFollowingModal
+          title="Following"
+          followersOrFollowing={followedUsers}
+        >
+          <Stat label="Following" value={user.followings} />
+        </FollowersAndFollowingModal>
       </div>
     </div>
   )


### PR DESCRIPTION
## Context
A few days ago, someone asked on Discord if it was possible to see their followers. Also, I had been noticing this need given the growth of the community and the public profile options.

I don't know if it's a real need right now, but I believe it would be a good visualization for users.

## Done
- Added a query to return `followed users` in `useFollowersAndFollowings` custom hook
- Created `FollowersAndFollowingModal` component and integrated with the user public profile

## Preview

https://www.loom.com/share/43ebf05959b4465caace2ce6b445907e?sid=5494369d-8c67-4053-842d-a81012ee0508