### PR TITLE
Feat/adjust toast search bar

### DIFF
--- a/src/components/top-bar/search-dialog/empty-state.tsx
+++ b/src/components/top-bar/search-dialog/empty-state.tsx
@@ -1,16 +1,28 @@
 import { Icons } from '@/components/icons'
 
+const SEARCH_ENTITIES = [
+  'forum posts',
+  'users',
+  'courses',
+  'interests',
+  'events',
+  'modules',
+  'videos'
+]
+
 export const EmptyState = () => (
   <>
     <div className="text-center px-6 py-14 sm:px-14">
       <Icons.fileSearch className="mx-auto w-8 h-8 text-gray-400" />
       <h2 className="mt-2 text-base font-semibold text-gray-900 dark:text-gray-100">
-        Search for
+        Search across our platform
       </h2>
-      <h6 className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-        posts and users.
-      </h6>
+      <div className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+        Find {SEARCH_ENTITIES.slice(0, -1).join(', ')} and{' '}
+        {SEARCH_ENTITIES.slice(-1)}.
+      </div>
     </div>
+
     <div className="hidden sm:flex flex-wrap items-center border-t bg-gray-50 px-4 py-2.5 text-xs text-gray-800 dark:bg-card dark:text-gray-100">
       <span className="mr-1">Press</span>
       <kbd className="pointer-events-none hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex">

--- a/src/components/top-bar/search-dialog/index.tsx
+++ b/src/components/top-bar/search-dialog/index.tsx
@@ -12,7 +12,7 @@ import { SearchInput } from './search-input'
 import { SearchResults } from './search-results'
 import { useEventModal } from '@/hooks/modal/use-event-modal'
 import { toast } from '@/components/ui/use-toast'
-import { FC } from 'react'
+import type { FC } from 'react'
 
 interface SearchDialogProps {
   isOpen: boolean

--- a/src/components/top-bar/search-dialog/index.tsx
+++ b/src/components/top-bar/search-dialog/index.tsx
@@ -11,6 +11,7 @@ import { type SearchDialogResult } from '@/hooks/search/types'
 import { SearchInput } from './search-input'
 import { SearchResults } from './search-results'
 import { useEventModal } from '@/hooks/modal/use-event-modal'
+import { toast } from '@/components/ui/use-toast'
 
 interface SearchDialogProps {
   isOpen: boolean
@@ -69,6 +70,13 @@ const SearchDialog: React.FC<SearchDialogProps> = ({ isOpen, onClose }) => {
               if (item.url) {
                 router.push(item.url)
                 handleClose()
+              }
+              if (item.entity === 'module' && !item.url) {
+                toast({
+                  title: 'This module has no videos',
+                  description: 'Please try again later'
+                })
+                return
               }
             }}
           >

--- a/src/components/top-bar/search-dialog/index.tsx
+++ b/src/components/top-bar/search-dialog/index.tsx
@@ -12,6 +12,7 @@ import { SearchInput } from './search-input'
 import { SearchResults } from './search-results'
 import { useEventModal } from '@/hooks/modal/use-event-modal'
 import { toast } from '@/components/ui/use-toast'
+import { FC } from 'react'
 
 interface SearchDialogProps {
   isOpen: boolean
@@ -19,7 +20,7 @@ interface SearchDialogProps {
   isMac: boolean
 }
 
-const SearchDialog: React.FC<SearchDialogProps> = ({ isOpen, onClose }) => {
+const SearchDialog: FC<SearchDialogProps> = ({ isOpen, onClose }) => {
   const router = useRouter()
   const { onOpen } = useEventModal()
 
@@ -76,7 +77,6 @@ const SearchDialog: React.FC<SearchDialogProps> = ({ isOpen, onClose }) => {
                   title: 'This module has no videos',
                   description: 'Please try again later'
                 })
-                return
               }
             }}
           >

--- a/src/components/top-bar/search-dialog/utils.ts
+++ b/src/components/top-bar/search-dialog/utils.ts
@@ -1,4 +1,3 @@
-import { toast } from '@/components/ui/use-toast'
 import { type SearchDialogResult } from '@/hooks/search/types'
 import { format } from 'date-fns'
 
@@ -62,10 +61,6 @@ export const getItemUrl = (item: SearchDialogResult): string | null => {
     case 'module': {
       const videoId = item.videos?.[0]?.id
       if (!videoId) {
-        toast({
-          title: 'This module has no videos',
-          description: 'Please try again later'
-        })
         return null
       }
       return `/mentorship/${encodeURIComponent(videoId)}`


### PR DESCRIPTION
## Description
- Display toast "This module has no videos" only when the user clicks, rather than triggering it in `handleSearch`.
- Update the top bar search's empty state text to include new entities.

## Preview 
https://github.com/user-attachments/assets/2a85a846-009e-44d1-b644-e7f6efff53b6

