### PR TITLE
Feat: profile season points display

### DIFF
--- a/src/app/(private)/(routes)/(member)/user/[userName]/components/Header.tsx
+++ b/src/app/(private)/(routes)/(member)/user/[userName]/components/Header.tsx
@@ -13,6 +13,15 @@ import { Icons } from '@/components/icons'
 import { PositionIconMap, TRAIL_LABELS } from '@/lib/constants'
 import { Positions, Roles } from '@/lib/types'
 import { FollowersAndFollowingModal } from './FollowersAndFollowingModal'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger
+} from '@/components/ui/tooltip'
+import { useSeason } from '@/hooks/season/use-season'
+import { format } from 'date-fns'
+import type { CurrentSeasonResponse } from '@/actions/leaderboard/types'
 
 const Header = ({
   user,
@@ -24,9 +33,11 @@ const Header = ({
   const { useGetScoreboardByUserId } = useScoreboard()
   const { follow, followers, unfollow, following, unfollowing, followedUsers } =
     useFollowersAndFollowings(user.id)
+  const { useGetCurrentSeason } = useSeason()
 
   const { data: scoreboard, refetch: refetchScoreboard } =
     useGetScoreboardByUserId(user.id)
+  const { data: currentSeason } = useGetCurrentSeason()
   const [isFollowed, setIsFollowed] = useState(false)
 
   useEffect(() => {
@@ -121,7 +132,11 @@ const Header = ({
         >
           <Stat label="Following" value={user.followings} />
         </FollowersAndFollowingModal>
-        <Stat label="Points" value={scoreboard?.data.points ?? 0} />
+        <PointsStat
+          label="Points"
+          value={scoreboard?.data.points ?? 0}
+          season={currentSeason}
+        />
       </div>
     </div>
   )
@@ -132,7 +147,91 @@ const Stat = ({ label, value }: { label: string; value: number }) => {
     <div>
       <p className="text-2xl font-semibold">{value}</p>
       <p className="text-gray-500">{label}</p>
+      <div className="h-5" />
     </div>
+  )
+}
+
+const PointsStat = ({
+  label,
+  value,
+  season
+}: {
+  label: string
+  value: number
+  season: CurrentSeasonResponse | undefined
+}) => {
+  return (
+    <TooltipProvider>
+      <Tooltip delayDuration={100}>
+        <TooltipTrigger asChild>
+          <div className="cursor-help w-fit mx-auto">
+            <p className="text-2xl font-semibold">{value}</p>
+            <p className="text-gray-500 border-b border-dashed border-gray-600 w-fit mx-auto">
+              {label}
+            </p>
+            {season && (
+              <p className="text-xs text-gray-600 mt-1">{season.name}</p>
+            )}
+          </div>
+        </TooltipTrigger>
+        {season && (
+          <TooltipContent
+            side="bottom"
+            className="font-mono text-left p-4 shadow-xl max-w-xs bg-background border border-border/50"
+          >
+            <h3 className="text-foreground font-semibold mb-1 flex items-center gap-2">
+              Current Season{' '}
+              <Icons.award className="w-[14px] h-[14px]" strokeWidth={2.5} />
+            </h3>
+            <div className="space-y-2 pt-2">
+              <div className="grid grid-cols-[0.5fr_1fr] gap-x-2 items-center">
+                <span className="text-gray-400">Season</span>
+                <span className="text-foreground">{season.name}</span>
+              </div>
+              <div className="grid grid-cols-[0.5fr_1fr] gap-x-2 items-center">
+                <span className="text-gray-400">Starts</span>
+                <span className="text-foreground">
+                  {format(new Date(season.initDate), 'MMM dd, yyyy')}
+                </span>
+              </div>
+              <div className="grid grid-cols-[0.5fr_1fr] gap-x-2 items-center">
+                <span className="text-gray-400">Ends</span>
+                <span className="text-foreground">
+                  {format(new Date(season.endDate), 'MMM dd, yyyy')}
+                </span>
+              </div>
+              {season.metadata?.description && (
+                <div className="grid grid-cols-[0.5fr_1fr] gap-x-2 items-start">
+                  <span className="text-gray-400">Description</span>
+                  <span className="text-foreground whitespace-pre-wrap truncate line-clamp-2">
+                    {season.metadata.description}
+                  </span>
+                </div>
+              )}
+              {season.metadata?.awards && season.metadata.awards.length > 0 && (
+                <div className="pt-2 mt-2 border-t border-border/50">
+                  <h3 className="text-foreground font-semibold mb-1">Awards</h3>
+                  <ul className="space-y-1">
+                    {season.metadata.awards.map(award => (
+                      <li
+                        key={award.position}
+                        className="grid grid-cols-[0.5fr_1fr] gap-x-2"
+                      >
+                        <span className="text-gray-400">{award.position}</span>
+                        <span className="text-foreground truncate line-clamp-1">
+                          {award.description}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          </TooltipContent>
+        )}
+      </Tooltip>
+    </TooltipProvider>
   )
 }
 

--- a/src/app/(private)/(routes)/(member)/user/[userName]/components/Header.tsx
+++ b/src/app/(private)/(routes)/(member)/user/[userName]/components/Header.tsx
@@ -213,7 +213,7 @@ const PointsStat = ({
                 <div className="pt-2 mt-2 border-t border-border/50">
                   <h3 className="text-foreground font-semibold mb-1">Awards</h3>
                   <ul className="space-y-1">
-                    {season.metadata.awards.map(award => (
+                    {season.metadata.awards.slice(0, 3).map(award => (
                       <li
                         key={award.position}
                         className="grid grid-cols-[0.5fr_1fr] gap-x-2"
@@ -224,6 +224,11 @@ const PointsStat = ({
                         </span>
                       </li>
                     ))}
+                    {season.metadata.awards.length > 3 && (
+                      <li className="text-gray-400 pt-1">
+                        +{season.metadata.awards.length - 3} more
+                      </li>
+                    )}
                   </ul>
                 </div>
               )}


### PR DESCRIPTION
## Description
This PR adds a new points stat component to the public profile header component, the goal is to display both the current user's points and the current season. It also adds a tooltip with the current season summary info.

## What type of PR is this?
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 📦 Chore
- [ ] ⏩ Revert

## Screenshots:
![CleanShot 2025-05-20 at 13 44 00@2x](https://github.com/user-attachments/assets/c978aa3f-a895-44ef-88cf-9941402aeacd)
![CleanShot 2025-05-20 at 13 43 28@2x](https://github.com/user-attachments/assets/6407f012-0652-4e2d-b617-55a0163b6750)
![CleanShot 2025-05-20 at 13 44 46@2x](https://github.com/user-attachments/assets/2667e8b0-e93e-4d47-92cd-6e9de6db68da)
![CleanShot 2025-05-20 at 13 44 55@2x](https://github.com/user-attachments/assets/817ed28c-8ba3-4d54-9b8c-2162de54d8d6)
![CleanShot 2025-05-20 at 13 48 20@2x](https://github.com/user-attachments/assets/ab433406-ac76-4435-b558-c221507a5454)

