### PR TITLE
fix: search user on leaderboard

### DIFF
--- a/src/actions/leaderboard/get-leaderboard-users.ts
+++ b/src/actions/leaderboard/get-leaderboard-users.ts
@@ -1,13 +1,29 @@
 import prismadb from '@/lib/prismadb'
+import type { Prisma } from '@prisma/client'
 import { type SearchedUserProps } from './types'
 
+export interface SearchUserInCurrentSeasonProps {
+  userId: string
+  points: number
+  user: {
+    id: string
+    name: string
+    username: string
+    level: string
+    position: string | null
+    imageUrl: string | null
+  }
+}
+
+export interface SearchUsersInCurrentSeasonResponse {
+  users: SearchUserInCurrentSeasonProps[]
+}
+
 export async function getLeaderboardUsers(
-  searchTerm?: string,
   page: number = 0,
   pageSize: number = 10
 ): Promise<SearchedUserProps[]> {
   try {
-    // Buscar a temporada atual
     const currentSeason = await prismadb.season.findFirst({
       where: { isCurrent: true },
       select: { id: true }
@@ -17,22 +33,11 @@ export async function getLeaderboardUsers(
       return []
     }
 
-    // Buscar usuários com base no termo de pesquisa
-    const scoreboardEntries = await prismadb.scoreboard.findMany({
+    const queryOptions = {
       where: {
-        seasonId: currentSeason.id,
-        user: searchTerm
-          ? {
-              OR: [
-                { name: { contains: searchTerm, mode: 'insensitive' } },
-                { username: { contains: searchTerm, mode: 'insensitive' } }
-              ]
-            }
-          : undefined
+        seasonId: currentSeason.id
       },
-      orderBy: {
-        points: 'desc'
-      },
+      orderBy: { points: 'desc' } as const,
       skip: page * pageSize,
       take: pageSize,
       include: {
@@ -47,7 +52,9 @@ export async function getLeaderboardUsers(
           }
         }
       }
-    })
+    }
+
+    const scoreboardEntries = await prismadb.scoreboard.findMany(queryOptions)
 
     return scoreboardEntries.map(entry => ({
       userId: entry.user.id,
@@ -63,6 +70,91 @@ export async function getLeaderboardUsers(
     }))
   } catch (error) {
     console.error('Error fetching leaderboard users:', error)
+    return []
+  }
+}
+
+export async function getSearchUsersInCurrentSeason(
+  searchTerm?: string,
+  limit: number = 20
+): Promise<SearchUserInCurrentSeasonProps[]> {
+  try {
+    if (!searchTerm) {
+      return []
+    }
+
+    const currentSeason = await prismadb.season.findFirst({
+      where: { isCurrent: true },
+      select: { id: true }
+    })
+
+    if (!currentSeason) {
+      return []
+    }
+
+    const where: Prisma.UserWhereInput = {
+      OR: [
+        { name: { contains: searchTerm, mode: 'insensitive' } },
+        { username: { contains: searchTerm, mode: 'insensitive' } }
+      ]
+    }
+
+    const users = await prismadb.user.findMany({
+      where,
+      orderBy: { name: 'asc' },
+      take: limit,
+      select: {
+        id: true,
+        name: true,
+        username: true,
+        level: true,
+        position: true,
+        imageUrl: true,
+        Scoreboard: {
+          where: {
+            seasonId: currentSeason.id
+          },
+          select: {
+            points: true
+          }
+        }
+      }
+    })
+
+    const usersWithScores = await Promise.all(
+      users.map(async user => {
+        let points = 0
+
+        if (user.Scoreboard.length > 0) {
+          points = user.Scoreboard[0].points
+        } else {
+          await prismadb.scoreboard.create({
+            data: {
+              userId: user.id,
+              seasonId: currentSeason.id,
+              points: 0
+            }
+          })
+        }
+
+        return {
+          userId: user.id,
+          points,
+          user: {
+            id: user.id,
+            name: user.name,
+            username: user.username,
+            level: user.level || '',
+            position: user.position || null,
+            imageUrl: user.imageUrl || null
+          }
+        }
+      })
+    )
+
+    return usersWithScores
+  } catch (error) {
+    console.error('Error searching users in current season:', error)
     return []
   }
 }

--- a/src/app/(private)/(routes)/(member)/dashboard/page.tsx
+++ b/src/app/(private)/(routes)/(member)/dashboard/page.tsx
@@ -9,11 +9,7 @@ import { getLeaderboardUsers } from '@/actions/leaderboard/get-leaderboard-users
 import type { SearchedUserProps } from '@/actions/leaderboard/types'
 
 export default async function Dashboard() {
-  const topUsers: SearchedUserProps[] = await getLeaderboardUsers(
-    undefined,
-    0,
-    5
-  )
+  const topUsers: SearchedUserProps[] = await getLeaderboardUsers(0, 5)
 
   return (
     <DefaultLayout className="overflow-hidden">

--- a/src/app/api/season/current/scoreboard/route.ts
+++ b/src/app/api/season/current/scoreboard/route.ts
@@ -1,21 +1,20 @@
 import { getLeaderboardUsers } from '@/actions/leaderboard/get-leaderboard-users'
 import { type NextRequest, NextResponse } from 'next/server'
 
-// GET /api/season/current/scoreboard - Search leaderboard users
+// GET /api/season/current/scoreboard - Get leaderboard users with pagination
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams
-    const searchTerm = searchParams.get('search') || undefined
     const page = parseInt(searchParams.get('page') || '0')
     const pageSize = parseInt(searchParams.get('pageSize') || '10')
 
-    const users = await getLeaderboardUsers(searchTerm, page, pageSize)
+    const users = await getLeaderboardUsers(page, pageSize)
 
     return NextResponse.json({ users })
   } catch (error) {
-    console.error('Error searching leaderboard users:', error)
+    console.error('Error fetching leaderboard users:', error)
     return NextResponse.json(
-      { error: 'Error searching leaderboard users' },
+      { error: 'Error fetching leaderboard users' },
       { status: 500 }
     )
   }

--- a/src/app/api/season/current/scoreboard/users/route.ts
+++ b/src/app/api/season/current/scoreboard/users/route.ts
@@ -1,0 +1,20 @@
+import { getSearchUsersInCurrentSeason } from '@/actions/leaderboard/get-leaderboard-users'
+import { type NextRequest, NextResponse } from 'next/server'
+
+// GET /api/season/current/scoreboard/users - Search users in current season
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = request.nextUrl.searchParams
+    const searchTerm = searchParams.get('search') || undefined
+
+    const users = await getSearchUsersInCurrentSeason(searchTerm, 20)
+
+    return NextResponse.json({ users })
+  } catch (error) {
+    console.error('Error searching users in current season:', error)
+    return NextResponse.json(
+      { error: 'Error searching users in current season' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/components/leaderboard/content.tsx
+++ b/src/components/leaderboard/content.tsx
@@ -7,7 +7,6 @@ import type {
 } from '@/actions/leaderboard/types'
 import { Icons } from '@/components/icons'
 import { InfiniteLeaderboard } from '@/components/leaderboard/infinite-leaderboard'
-import { InfiniteLeaderboardEmptyState } from '@/components/leaderboard/infinite-leaderboard-empty-state'
 import { LeaderboardSkeleton } from '@/components/leaderboard/skeleton'
 import { TopThree } from '@/components/leaderboard/top-three'
 import { Button } from '@/components/ui/button'
@@ -116,14 +115,8 @@ export const LeaderboardContent = ({ data }: LeaderboardContentProps) => {
       </div>
       <Separator className="my-2 sm:my-4" />
       <TopThree scores={seasonData.scores} />
-      {initialLeaderboardData.users.length > 0 ? (
-        <>
-          <Separator className="my-2 sm:my-4" />
-          <InfiniteLeaderboard initialData={initialLeaderboardData} />
-        </>
-      ) : (
-        <InfiniteLeaderboardEmptyState />
-      )}
+      <Separator className="my-2 sm:my-4" />
+      <InfiniteLeaderboard initialData={initialLeaderboardData} />
     </Card>
   )
 }

--- a/src/components/leaderboard/infinite-leaderboard-empty-state.tsx
+++ b/src/components/leaderboard/infinite-leaderboard-empty-state.tsx
@@ -4,16 +4,16 @@ import { Icons } from '@/components/icons'
 
 export const InfiniteLeaderboardEmptyState = () => {
   return (
-    <div className="flex-1 flex flex-col items-center justify-center py-8 mt-2 rounded-lg px-4">
+    <div className="flex-1 flex flex-col items-center justify-start pt-0 pb-8 rounded-lg px-4 mt-2">
       <Icons.trophy className="w-16 h-16 text-muted-foreground" />
-      <h3 className="text-lg font-medium text-muted-foreground mt-4 text-center">
+      <h3 className="text-lg font-medium text-muted-foreground mt-2 text-center">
         Legends are being made! Will you be next?
       </h3>
       <p className="text-sm text-muted-foreground/70 mt-1 max-w-md text-center">
         Earn points through community engagement and contributions to rank on
         this season&apos;s leaderboard.
       </p>
-      <div className="mt-8 grid grid-cols-3 gap-4 opacity-30">
+      <div className="mt-6 grid grid-cols-3 gap-4 opacity-30">
         {[...Array(3)].map((_, i) => (
           <div
             key={i}

--- a/src/components/leaderboard/search-users-skeleton.tsx
+++ b/src/components/leaderboard/search-users-skeleton.tsx
@@ -5,7 +5,7 @@ export const SearchUsersSkeleton = () => {
     <div className="flex flex-col gap-y-4">
       {Array.from({ length: 3 }).map((_, i) => (
         <div
-          key={i + i}
+          key={i}
           className="flex items-center justify-between p-2 rounded-lg animate-pulse"
         >
           <div className="flex items-center gap-x-2 sm:gap-x-3 min-w-0 flex-1">

--- a/src/components/leaderboard/search-users-skeleton.tsx
+++ b/src/components/leaderboard/search-users-skeleton.tsx
@@ -1,0 +1,31 @@
+import { Skeleton } from '@/components/ui/skeleton'
+
+export const SearchUsersSkeleton = () => {
+  return (
+    <div className="flex flex-col gap-y-4">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div
+          key={i + i}
+          className="flex items-center justify-between p-2 rounded-lg animate-pulse"
+        >
+          <div className="flex items-center gap-x-2 sm:gap-x-3 min-w-0 flex-1">
+            <Skeleton className="h-6 w-6 sm:h-8 sm:w-8 rounded-full flex-shrink-0" />
+            <Skeleton className="h-8 w-8 sm:h-10 sm:w-10 rounded-full flex-shrink-0" />
+            <div className="flex flex-col gap-2 min-w-0 flex-1">
+              <Skeleton className="h-4 w-24 sm:w-32" />
+              <Skeleton className="h-3 w-16 sm:w-20" />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-1 sm:gap-3 flex-shrink-0">
+            <div className="flex flex-wrap gap-1 sm:gap-2 justify-end">
+              <Skeleton className="h-6 w-12 sm:w-16 rounded-md" />
+              <Skeleton className="h-6 w-10 sm:w-12 rounded-md" />
+            </div>
+            <Skeleton className="h-4 w-8 sm:w-12" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/hooks/season/use-season.ts
+++ b/src/hooks/season/use-season.ts
@@ -1,3 +1,4 @@
+import type { SearchUsersInCurrentSeasonResponse } from '@/actions/leaderboard/get-leaderboard-users'
 import { api } from '@/lib/api'
 import {
   type UseQueryOptions,
@@ -37,24 +38,6 @@ export const useSeason = () => {
       ...options
     })
 
-  const useSearchLeaderboardUsers = (
-    searchTerm: string,
-    options?: UseQueryOptions<SearchLeaderboardUsersApiProps, AxiosError>
-  ) =>
-    useQuery({
-      queryKey: ['searchLeaderboardUsers', searchTerm],
-      queryFn: async () => {
-        const response = await api.get<SearchLeaderboardUsersApiProps>(
-          `/api/season/current/scoreboard?search=${encodeURIComponent(
-            searchTerm
-          )}`
-        )
-        return response.data
-      },
-      enabled: !!searchTerm && searchTerm.length >= 2,
-      ...options
-    })
-
   const useInfiniteLeaderboardUsers = (
     searchTerm: string,
     pageSize: number = 10,
@@ -78,10 +61,28 @@ export const useSeason = () => {
       ...(options as Record<string, unknown>)
     })
 
+  const useSearchUsersInCurrentSeason = (
+    searchTerm: string,
+    options?: UseQueryOptions<SearchUsersInCurrentSeasonResponse, AxiosError>
+  ) =>
+    useQuery({
+      queryKey: ['searchUsersInCurrentSeason', searchTerm],
+      queryFn: async () => {
+        const response = await api.get<SearchUsersInCurrentSeasonResponse>(
+          `/api/season/current/scoreboard/users?search=${encodeURIComponent(
+            searchTerm
+          )}`
+        )
+        return response.data
+      },
+      enabled: !!searchTerm && searchTerm.length >= 2,
+      ...options
+    })
+
   return {
     useGetCurrentSeason,
     useGetAllSeasons,
-    useSearchLeaderboardUsers,
-    useInfiniteLeaderboardUsers
+    useInfiniteLeaderboardUsers,
+    useSearchUsersInCurrentSeason
   }
 }


### PR DESCRIPTION
Fix search input user on leaderboard page.

Now, the request is searching on users table and doing a join with scoreboard table. If doesn't exists user score com scoreboard table, will be created one register to this user.

Also, there are some UI improvements (loading skeleton, placeholder spacing adjustament, etc.)