### PR TITLE
Fix: Public profile own user

### DIFF
--- a/src/app/(private)/(routes)/(member)/user/[userName]/page.tsx
+++ b/src/app/(private)/(routes)/(member)/user/[userName]/page.tsx
@@ -74,10 +74,7 @@ const PublicProfile = async ({ params }: PublicProfileProps) => {
           </TabsContent>
         </Tabs>
       ) : (
-        <>
-          <CreatePostCommentComponent />
-          <UserPosts posts={profileUser?.posts} loggedInUserId={user.id} />
-        </>
+        <UserPosts posts={profileUser?.posts} loggedInUserId={user.id} />
       )}
     </DefaultLayout>
   )


### PR DESCRIPTION
# Description
This pull request addresses a bug where users can create a new post while viewing another user's public profile. According to the intended functionality, the option to create a post should only be available on the user's own profile.

# Changes

- Implemented checks to ensure the "Create Post" option is only visible on the user's personal profile.