### PR TITLE
Feat: Add Toggle Button for Season Activation

### DIFF
--- a/src/app/(private)/(routes)/admin/seasons/components/columns.tsx
+++ b/src/app/(private)/(routes)/admin/seasons/components/columns.tsx
@@ -7,7 +7,9 @@ import { SeasonDataTableRowActions } from './season-data-table-row-actions'
 import { Badge } from '@/components/ui/badge'
 import { type Season } from '@prisma/client'
 
-export const seasonsColumns: Array<ColumnDef<Season>> = [
+export const createSeasonsColumns = (
+  refetch: () => void
+): Array<ColumnDef<Season>> => [
   {
     accessorKey: 'name',
     header: 'Name',
@@ -66,6 +68,8 @@ export const seasonsColumns: Array<ColumnDef<Season>> = [
   {
     id: 'actions',
     header: 'Actions',
-    cell: ({ row }) => <SeasonDataTableRowActions data={row.original} />
+    cell: ({ row }) => (
+      <SeasonDataTableRowActions data={row.original} refetch={refetch} />
+    )
   }
 ]

--- a/src/app/(private)/(routes)/admin/seasons/components/seasons-list.tsx
+++ b/src/app/(private)/(routes)/admin/seasons/components/seasons-list.tsx
@@ -8,7 +8,7 @@ import { useSeason } from '@/hooks/season/use-season'
 import { Can } from '@/hooks/use-ability'
 import { appRoutes } from '@/lib/constants'
 import { useRouter } from 'next/navigation'
-import { seasonsColumns } from './columns'
+import { createSeasonsColumns } from './columns'
 import { useCallback } from 'react'
 import { ErrorState } from './error-state'
 import { EmptyState } from './empty-state'
@@ -21,7 +21,8 @@ const SeasonsList = () => {
     data: seasonsData,
     isLoading,
     isError,
-    error
+    error,
+    refetch
   } = useGetAllSeasons({
     queryKey: ['getAllSeasons'],
     staleTime: 10 * 60 * 1000,
@@ -82,7 +83,11 @@ const SeasonsList = () => {
           </Button>
         </Can>
       </Header>
-      <DataTable searchKey="name" columns={seasonsColumns} data={seasons} />
+      <DataTable
+        searchKey="name"
+        columns={createSeasonsColumns(refetch)}
+        data={seasons}
+      />
     </>
   )
 }


### PR DESCRIPTION
Implements a shortcut button in the "actions" column of the CMS seasons page to enable/disable the current season.

<img width="236" alt="image" src="https://github.com/user-attachments/assets/5bd07cb8-0bed-4177-9d6d-041fc4fd6fde" />
