### PR TITLE
feat: Implement Pagination for Score Activities

### DIFF
--- a/src/app/(private)/(routes)/admin/seasons/[seasonId]/score-activities/components/score-timeline/index.tsx
+++ b/src/app/(private)/(routes)/admin/seasons/[seasonId]/score-activities/components/score-timeline/index.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { Badge } from '@/components/ui/badge'
-import { Skeleton } from '@/components/ui/skeleton'
 import {
   Timeline,
   TimelineContent,
@@ -16,45 +15,105 @@ import { type ScoreHistoryItem } from '@/hooks/score-history/types'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
 import useScoreTimeline from './use-score-timeline'
-import { Button } from '@/components/ui/button'
-import { Icons } from '@/components/icons'
 import { appRoutes } from '@/lib/constants'
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious
+} from '@/components/ui/pagination'
+import BackButton from '@/components/back-button'
+import { DOTS, usePagination } from '@/hooks/use-pagination'
 
 type ScoreTimelineProps = {
-  seasonId: string
   initialData?: ScoreHistoryItem[]
-  initialDataCount?: number
+  page: number
+  limit: number
+  total: number
 }
 
 const ScoreTimeline = ({
-  seasonId,
   initialData = [],
-  initialDataCount = 0
+  page,
+  limit,
+  total
 }: ScoreTimelineProps) => {
-  const {
-    data,
-    isLoading,
-    isFetchingNextPage,
-    ref,
-    formatSourceType,
-    formatTimeAgo
-  } = useScoreTimeline(seasonId, initialData, initialDataCount)
+  const { data, pageCount, handlePageChange, formatSourceType, formatTimeAgo } =
+    useScoreTimeline(initialData, page, limit, total)
 
-  if (isLoading && data.length === 0) {
-    return <div>Loading...</div>
+  const paginationRange = usePagination({
+    pageCount,
+    page
+  })
+
+  const renderPagination = () => {
+    if (pageCount <= 1 || !paginationRange) return null
+
+    return (
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious
+              href="#"
+              onClick={e => {
+                e.preventDefault()
+                handlePageChange(page - 1)
+              }}
+              aria-disabled={page <= 1}
+              className={cn({
+                'pointer-events-none opacity-50': page <= 1
+              })}
+            />
+          </PaginationItem>
+          {paginationRange.map((pageNumber, index) => {
+            if (pageNumber === DOTS) {
+              return (
+                <PaginationItem key={`${DOTS}-${index}`}>
+                  <PaginationEllipsis />
+                </PaginationItem>
+              )
+            }
+
+            return (
+              <PaginationItem key={pageNumber}>
+                <PaginationLink
+                  href="#"
+                  onClick={e => {
+                    e.preventDefault()
+                    handlePageChange(pageNumber as number)
+                  }}
+                  isActive={pageNumber === page}
+                >
+                  {pageNumber}
+                </PaginationLink>
+              </PaginationItem>
+            )
+          })}
+          <PaginationItem>
+            <PaginationNext
+              href="#"
+              onClick={e => {
+                e.preventDefault()
+                handlePageChange(page + 1)
+              }}
+              aria-disabled={page >= pageCount}
+              className={cn({
+                'pointer-events-none opacity-50': page >= pageCount
+              })}
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    )
   }
 
   return (
     <div className="space-y-4">
-      <Button variant="outline" asChild>
-        <Link
-          href={appRoutes.admin_seasons}
-          className="flex items-center gap-2"
-        >
-          <Icons.arrowBack className="h-4 w-4" /> Back to Seasons
-        </Link>
-      </Button>
       <div className="flex items-center">
+        <BackButton route={appRoutes.admin_seasons} />
         <h2 className="text-2xl font-bold">Score Activities</h2>
       </div>
 
@@ -65,72 +124,67 @@ const ScoreTimeline = ({
           </p>
         </div>
       ) : (
-        <Timeline>
-          {data.map((item, index) => (
-            <TimelineItem
-              key={item.id}
-              step={index}
-              className="group-data-[orientation=vertical]/timeline:ms-10 group-data-[orientation=vertical]/timeline:not-last:pb-8 mb-4"
-            >
-              <TimelineHeader>
-                <TimelineSeparator className="group-data-[orientation=vertical]/timeline:-left-6 group-data-[orientation=vertical]/timeline:h-full mt-1.5 group-data-[orientation=vertical]/timeline:translate-y-6.5" />
-                <TimelineTitle className="mt-0.5 flex items-center gap-2">
-                  <Badge
-                    className={cn(
-                      'text-white gap-x-2 hover:bg-transparent',
-                      'inline-flex items-center rounded-md bg-gray-400/10 px-2 py-1 text-xs font-medium text-gray-400 ring-1 ring-inset ring-gray-400/30 hover:bg-gray-400/20'
-                    )}
-                  >
-                    {item.season.name}
-                  </Badge>
-                </TimelineTitle>
-                <TimelineIndicator className="h-4 w-4 border-2 border-muted-foreground bg-background absolute -left-9 mt-1.5" />
-              </TimelineHeader>
-              <TimelineContent className="text-foreground mt-2 rounded-lg border px-4 py-3">
-                {item.target ? (
-                  <>
-                    <Link
-                      href={`/user/${item.user.username}`}
-                      className="font-medium text-primary hover:underline"
+        <>
+          <Timeline>
+            {data.map((item, index) => (
+              <TimelineItem
+                key={item.id}
+                step={index}
+                className="group-data-[orientation=vertical]/timeline:ms-10 group-data-[orientation=vertical]/timeline:not-last:pb-8 mb-4"
+              >
+                <TimelineHeader>
+                  <TimelineSeparator className="group-data-[orientation=vertical]/timeline:-left-6 group-data-[orientation=vertical]/timeline:h-full mt-1.5 group-data-[orientation=vertical]/timeline:translate-y-6.5" />
+                  <TimelineTitle className="mt-0.5 flex items-center gap-2">
+                    <Badge
+                      className={cn(
+                        'text-white gap-x-2 hover:bg-transparent',
+                        'inline-flex items-center rounded-md bg-gray-400/10 px-2 py-1 text-xs font-medium text-gray-400 ring-1 ring-inset ring-gray-400/30 hover:bg-gray-400/20'
+                      )}
                     >
-                      {item.user.name}
-                    </Link>{' '}
-                    generated {item.points} points for{' '}
-                    <Link
-                      href={`/user/${item.target.username}`}
-                      className="font-medium text-primary hover:underline"
-                    >
-                      {item.target.name}
-                    </Link>{' '}
-                    by {formatSourceType(item.resource.resource)}
-                  </>
-                ) : (
-                  <>
-                    <Link
-                      href={`/user/${item.user.id}`}
-                      className="font-medium text-primary hover:underline"
-                    >
-                      {item.user.name}
-                    </Link>{' '}
-                    received {item.points} points by{' '}
-                    {formatSourceType(item.resource.resource)}
-                  </>
-                )}
-                <TimelineDate className="mt-1 mb-0">
-                  {formatTimeAgo(item.createdAt)}
-                </TimelineDate>
-              </TimelineContent>
-            </TimelineItem>
-          ))}
-
-          <div ref={ref} className="h-10">
-            {isFetchingNextPage && (
-              <div className="flex justify-center py-4">
-                <Skeleton className="h-8 w-8 rounded-full" />
-              </div>
-            )}
-          </div>
-        </Timeline>
+                      {item.season.name}
+                    </Badge>
+                  </TimelineTitle>
+                  <TimelineIndicator className="h-4 w-4 border-2 border-muted-foreground bg-background absolute -left-9 mt-1.5" />
+                </TimelineHeader>
+                <TimelineContent className="text-foreground mt-2 rounded-lg border px-4 py-3">
+                  {item.target ? (
+                    <>
+                      <Link
+                        href={`/user/${item.user.username}`}
+                        className="font-medium text-primary hover:underline"
+                      >
+                        {item.user.name}
+                      </Link>{' '}
+                      generated {item.points} points for{' '}
+                      <Link
+                        href={`/user/${item.target.username}`}
+                        className="font-medium text-primary hover:underline"
+                      >
+                        {item.target.name}
+                      </Link>{' '}
+                      by {formatSourceType(item.resource.resource)}
+                    </>
+                  ) : (
+                    <>
+                      <Link
+                        href={`/user/${item.user.id}`}
+                        className="font-medium text-primary hover:underline"
+                      >
+                        {item.user.name}
+                      </Link>{' '}
+                      received {item.points} points by{' '}
+                      {formatSourceType(item.resource.resource)}
+                    </>
+                  )}
+                  <TimelineDate className="mt-1 mb-0">
+                    {formatTimeAgo(item.createdAt)}
+                  </TimelineDate>
+                </TimelineContent>
+              </TimelineItem>
+            ))}
+          </Timeline>
+          {renderPagination()}
+        </>
       )}
     </div>
   )

--- a/src/app/(private)/(routes)/admin/seasons/[seasonId]/score-activities/page.tsx
+++ b/src/app/(private)/(routes)/admin/seasons/[seasonId]/score-activities/page.tsx
@@ -1,27 +1,27 @@
 import { getScoreActivityBySeason } from '@/actions/season/get-score-activity-by-season'
 import { DefaultLayout } from '@/components/default-layout'
-import { Suspense } from 'react'
 import ScoreTimeline from './components/score-timeline'
-import ScoreTimelineSkeleton from './components/skeleton'
 
 const ScoreActivitiesPage = async ({
-  params
+  params,
+  searchParams
 }: {
   params: { seasonId: string }
+  searchParams: { page?: string }
 }) => {
-  const formattedScoreActivities = await getScoreActivityBySeason(
-    params.seasonId
-  )
+  const page = Number(searchParams.page) || 1
+  const limit = 10
+
+  const data = await getScoreActivityBySeason(params.seasonId, page, limit)
 
   return (
     <DefaultLayout>
-      <Suspense fallback={<ScoreTimelineSkeleton />}>
-        <ScoreTimeline
-          initialData={formattedScoreActivities}
-          initialDataCount={formattedScoreActivities.length}
-          seasonId={params.seasonId}
-        />
-      </Suspense>
+      <ScoreTimeline
+        initialData={data.activities}
+        page={page}
+        limit={limit}
+        total={data.total}
+      />
     </DefaultLayout>
   )
 }

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,0 +1,116 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { ButtonProps, buttonVariants } from "@/components/ui/button"
+import { ChevronLeftIcon, ChevronRightIcon, DotsHorizontalIcon } from "@radix-ui/react-icons"
+
+const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
+  <nav
+    role="navigation"
+    aria-label="pagination"
+    className={cn("mx-auto flex w-full justify-center", className)}
+    {...props}
+  />
+)
+Pagination.displayName = "Pagination"
+
+const PaginationContent = React.forwardRef<
+  HTMLUListElement,
+  React.ComponentProps<"ul">
+>(({ className, ...props }, ref) => (
+  <ul
+    ref={ref}
+    className={cn("flex flex-row items-center gap-1", className)}
+    {...props}
+  />
+))
+PaginationContent.displayName = "PaginationContent"
+
+const PaginationItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentProps<"li">
+>(({ className, ...props }, ref) => (
+  <li ref={ref} className={cn("", className)} {...props} />
+))
+PaginationItem.displayName = "PaginationItem"
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<ButtonProps, "size"> &
+  React.ComponentProps<"a">
+
+const PaginationLink = ({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) => (
+  <a
+    aria-current={isActive ? "page" : undefined}
+    className={cn(
+      buttonVariants({
+        variant: isActive ? "outline" : "ghost",
+        size,
+      }),
+      className
+    )}
+    {...props}
+  />
+)
+PaginationLink.displayName = "PaginationLink"
+
+const PaginationPrevious = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to previous page"
+    size="default"
+    className={cn("gap-1 pl-2.5", className)}
+    {...props}
+  >
+    <ChevronLeftIcon className="h-4 w-4" />
+    <span>Previous</span>
+  </PaginationLink>
+)
+PaginationPrevious.displayName = "PaginationPrevious"
+
+const PaginationNext = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to next page"
+    size="default"
+    className={cn("gap-1 pr-2.5", className)}
+    {...props}
+  >
+    <span>Next</span>
+    <ChevronRightIcon className="h-4 w-4" />
+  </PaginationLink>
+)
+PaginationNext.displayName = "PaginationNext"
+
+const PaginationEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<"span">) => (
+  <span
+    aria-hidden
+    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    {...props}
+  >
+    <DotsHorizontalIcon className="h-4 w-4" />
+    <span className="sr-only">More pages</span>
+  </span>
+)
+PaginationEllipsis.displayName = "PaginationEllipsis"
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+}

--- a/src/hooks/use-pagination.ts
+++ b/src/hooks/use-pagination.ts
@@ -1,0 +1,78 @@
+import { useMemo } from 'react'
+
+export const DOTS = '...'
+
+const range = (start: number, end: number) => {
+  const length = end - start + 1
+  return Array.from({ length }, (_, idx) => idx + start)
+}
+
+type UsePaginationProps = {
+  pageCount: number
+  siblingCount?: number
+  page: number
+}
+
+export const usePagination = ({
+  pageCount,
+  siblingCount = 1,
+  page
+}: UsePaginationProps) => {
+  const paginationRange = useMemo(() => {
+    // Pages count is determined as siblingCount + firstPage + lastPage + currentPage + 2*DOTS
+    const totalPageNumbers = siblingCount + 5
+
+    /*
+      Case 1:
+      If the number of pages is less than the page numbers we want to show in our
+      paginationComponent, we return the range [1..pageCount]
+    */
+    if (totalPageNumbers >= pageCount) {
+      return range(1, pageCount)
+    }
+
+    /*
+    	Calculate left and right sibling index and make sure they are within range 1 and pageCount
+    */
+    const leftSiblingIndex = Math.max(page - siblingCount, 1)
+    const rightSiblingIndex = Math.min(page + siblingCount, pageCount)
+
+    /*
+      We do not show dots just when there is just one page number to be inserted between the extremes of sibling and the page limits i.e 1 and pageCount. Hence, we are using leftSiblingIndex > 2 and rightSiblingIndex < pageCount - 2
+    */
+    const shouldShowLeftDots = leftSiblingIndex > 2
+    const shouldShowRightDots = rightSiblingIndex < pageCount - 2
+
+    const firstPageIndex = 1
+    const lastPageIndex = pageCount
+
+    /*
+    	Case 2: No left dots to show, but rights dots to be shown
+    */
+    if (!shouldShowLeftDots && shouldShowRightDots) {
+      const leftItemCount = 3 + 2 * siblingCount
+      const leftRange = range(1, leftItemCount)
+
+      return [...leftRange, DOTS, pageCount]
+    }
+
+    /*
+    	Case 3: No right dots to show, but left dots to be shown
+    */
+    if (shouldShowLeftDots && !shouldShowRightDots) {
+      const rightItemCount = 3 + 2 * siblingCount
+      const rightRange = range(pageCount - rightItemCount + 1, pageCount)
+      return [firstPageIndex, DOTS, ...rightRange]
+    }
+
+    /*
+    	Case 4: Both left and right dots to be shown
+    */
+    if (shouldShowLeftDots && shouldShowRightDots) {
+      const middleRange = range(leftSiblingIndex, rightSiblingIndex)
+      return [firstPageIndex, DOTS, ...middleRange, DOTS, lastPageIndex]
+    }
+  }, [pageCount, siblingCount, page])
+
+  return paginationRange
+}


### PR DESCRIPTION
# Description

This pull request replaces the infinite scroll functionality on the Score Activities page with a robust, page-based navigation system. It introduces a reusable pagination hook and leverages the existing `pagination.tsx` component to create a more structured and user-friendly experience for browsing score history.

## Changes

*   **Paginated Data Fetching:**
    *   The `getScoreActivityBySeason` server action in `src/actions/season/get-score-activity-by-season.ts` has been updated to accept `page` and `limit` parameters.
    *   It now fetches a specific slice of activities and returns the `total` count for pagination purposes.

*   **URL-Based State Management:**
    *   The Score Activities page (`src/app/(private)/(routes)/admin/seasons/[seasonId]/score-activities/page.tsx`) now reads the current page number from the URL search parameters (e.g., `?page=2`).
    *   This ensures that the page state is bookmarkable and shareable.

*   **Refactored `useScoreTimeline` Hook:**
    *   The `useScoreTimeline` hook has been completely refactored to manage pagination state. It no longer handles data fetching but instead computes page count and provides a `handlePageChange` function to navigate between pages by updating the URL.

*   **Reusable `usePagination` Hook:**
    *   A new hook, `usePagination`, has been created at `src/hooks/use-pagination.ts`.
    *   This hook contains the logic for generating a pagination range with ellipses (`...`) when there are many pages, providing a clean and scalable user experience.

*   **UI Integration:**
    *   The `ScoreTimeline` component now utilizes the `usePagination` hook to render the complete pagination controls, including previous/next buttons, page numbers, and ellipses.
    *   The UI gracefully handles disabled states for previous/next buttons and correctly highlights the active page.