### PR TITLE
Feat/Exclude disabled users from leaderboard

### DIFF
--- a/src/actions/leaderboard/get-current-season.ts
+++ b/src/actions/leaderboard/get-current-season.ts
@@ -9,6 +9,11 @@ export async function getCurrentSeason(): Promise<CurrentSeasonResponse> {
       where: { isCurrent: true },
       include: {
         scores: {
+          where: {
+            user: {
+              isDisabled: false
+            }
+          },
           orderBy: {
             points: 'desc'
           },
@@ -21,7 +26,8 @@ export async function getCurrentSeason(): Promise<CurrentSeasonResponse> {
                 username: true,
                 level: true,
                 position: true,
-                imageUrl: true
+                imageUrl: true,
+                isDisabled: true
               }
             }
           }

--- a/src/actions/leaderboard/get-leaderboard-users.ts
+++ b/src/actions/leaderboard/get-leaderboard-users.ts
@@ -12,6 +12,7 @@ export interface SearchUserInCurrentSeasonProps {
     level: string
     position: string | null
     imageUrl: string | null
+    isDisabled: boolean | null
   }
 }
 
@@ -35,7 +36,10 @@ export async function getLeaderboardUsers(
 
     const queryOptions: Prisma.ScoreboardFindManyArgs = {
       where: {
-        seasonId: currentSeason.id
+        seasonId: currentSeason.id,
+        user: {
+          isDisabled: false
+        }
       },
       orderBy: [{ points: 'desc' }, { userId: 'asc' }],
       skip: page * pageSize,
@@ -48,7 +52,8 @@ export async function getLeaderboardUsers(
             username: true,
             level: true,
             position: true,
-            imageUrl: true
+            imageUrl: true,
+            isDisabled: true
           }
         }
       }
@@ -67,7 +72,8 @@ export async function getLeaderboardUsers(
         username: entry.user.username,
         level: entry.user.level || '',
         position: entry.user.position || null,
-        imageUrl: entry.user.imageUrl || null
+        imageUrl: entry.user.imageUrl || null,
+        isDisabled: entry.user.isDisabled || false
       }
     }))
   } catch (error) {
@@ -98,7 +104,8 @@ export async function getSearchUsersInCurrentSeason(
       OR: [
         { name: { contains: searchTerm, mode: 'insensitive' } },
         { username: { contains: searchTerm, mode: 'insensitive' } }
-      ]
+      ],
+      isDisabled: false
     }
 
     const users = await prismadb.user.findMany({
@@ -112,6 +119,7 @@ export async function getSearchUsersInCurrentSeason(
         level: true,
         position: true,
         imageUrl: true,
+        isDisabled: true,
         Scoreboard: {
           where: {
             seasonId: currentSeason.id
@@ -148,7 +156,8 @@ export async function getSearchUsersInCurrentSeason(
             username: user.username,
             level: user.level || '',
             position: user.position || null,
-            imageUrl: user.imageUrl || null
+            imageUrl: user.imageUrl || null,
+            isDisabled: user.isDisabled || false
           }
         }
       })

--- a/src/actions/leaderboard/types.ts
+++ b/src/actions/leaderboard/types.ts
@@ -15,6 +15,7 @@ export type LeaderboardUser = {
   level: string | null
   position: Positions | null
   imageUrl?: string | null
+  isDisabled?: boolean | null
 }
 
 export type LeaderboardScore = {
@@ -47,6 +48,7 @@ export interface SearchedUserProps {
     level: string
     position: string | null
     imageUrl: string | null
+    isDisabled?: boolean | null
   }
 }
 

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -38,7 +38,10 @@ export async function POST(request: NextRequest) {
         }),
 
         prismadb.user.findMany({
-          where: { username: { contains: keyword, mode: 'insensitive' } },
+          where: {
+            username: { contains: keyword, mode: 'insensitive' },
+            isDisabled: false
+          },
           select: {
             id: true,
             username: true,


### PR DESCRIPTION
# Description
Exclude disabled user accounts from appearing in community leaderboards to maintain competitive integrity. Also, remove disabled users from search results.

# Changes
- Remove disabled users from search results
- Added `isDisabled` filter in `get-leaderboard-users.ts` service
- Updated `get-current-season.ts` to handle disabled user edge cases
- Modified leaderboard type definitions in `types.ts` to support filtering
- Implemented conditional checks in data fetching operations