### PR TITLE
Feat/code up support

### DIFF
--- a/prisma/migrations/20250716220920_add_supports_to_notes/migration.sql
+++ b/prisma/migrations/20250716220920_add_supports_to_notes/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "NoteSupport" (
+    "userId" TEXT NOT NULL,
+    "noteId" TEXT NOT NULL,
+
+    CONSTRAINT "NoteSupport_pkey" PRIMARY KEY ("userId","noteId")
+);
+
+-- AddForeignKey
+ALTER TABLE "NoteSupport" ADD CONSTRAINT "NoteSupport_noteId_fkey" FOREIGN KEY ("noteId") REFERENCES "Note"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "NoteSupport" ADD CONSTRAINT "NoteSupport_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model User {
   ScoreHistory  ScoreHistory[]
   Scoreboard    Scoreboard[]
   interests     UserInterest[]
+  noteSupports  NoteSupport[]
 }
 
 model UserFollowersAndFollowing {
@@ -260,6 +261,16 @@ model Note {
   userId    String
   isPublic  Boolean  @default(false)
   user      User     @relation(fields: [userId], references: [id])
+  supports  NoteSupport[]
+}
+
+model NoteSupport {
+  userId    String
+  noteId    String
+  note      Note     @relation(fields: [noteId], references: [id])
+  user      User     @relation(fields: [userId], references: [id])
+
+  @@id([userId, noteId])
 }
 
 model Event {

--- a/src/app/(private)/(routes)/(member)/dashboard/components/note-supports/index.tsx
+++ b/src/app/(private)/(routes)/(member)/dashboard/components/note-supports/index.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { useNoteSupports } from "./use-note-supports"
+import { Icons } from "@/components/icons"
+import { type ExtendedNote } from "@/lib/types"
+
+type NoteSupportsProps = {
+    note: ExtendedNote
+    loggedInUserId: string
+}
+
+const NoteSupports = ({ note, loggedInUserId }: NoteSupportsProps) => {
+    const { handleSupport, supportState, isPending } = useNoteSupports({
+        note,
+        loggedInUserId
+    })
+
+    if (!note) {
+        return null
+    }
+
+    return (
+        <div className="flex ml-2 items-center w-fit space-x-1 font-bold transition-colors dark:text-white text-black text-sm">
+            <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleSupport}
+                disabled={isPending}
+                className={cn(
+                    'flex items-center gap-x-2 hover:bg-transparent hover:text-accent',
+                    isPending && 'cursor-not-allowed opacity-50'
+                )}
+            >
+                <Icons.rocket
+                    data-user-supported={supportState.supported}
+                    className={cn(
+                        supportState.supported && 'text-primary',
+                        'data-[user-supported=true]:h-5 data-[user-supported=true]:w-5 h-4 w-4'
+                    )}
+                />
+                <span
+                    data-user-supported={supportState.supported}
+                    className="data-[user-supported=true]:text-primary font-semibold text-sm"
+                >
+                    {supportState.supports}
+                </span>
+            </Button>
+        </div>
+    )
+}
+
+
+export default NoteSupports

--- a/src/app/(private)/(routes)/(member)/dashboard/components/note-supports/use-note-supports.ts
+++ b/src/app/(private)/(routes)/(member)/dashboard/components/note-supports/use-note-supports.ts
@@ -1,0 +1,58 @@
+import { toast } from "@/components/ui/use-toast"
+import { useNote } from "@/hooks/note/use-note"
+import { type ExtendedNote } from "@/lib/types"
+import { useReducer } from "react"
+
+type UseNoteSupportsProps = {
+    note: ExtendedNote
+    loggedInUserId: string
+}
+
+
+export const useNoteSupports = ({ note, loggedInUserId }: UseNoteSupportsProps) => {
+    const { useSupportNote } = useNote()
+
+    const [supportState, dispatch] = useReducer(
+        (state: { supports: number; supported: boolean }, action: { type: string }) => {
+            switch (action.type) {
+                case 'SUPPORT':
+                    return { ...state, supported: true, supports: state.supports + 1 }
+                case 'UNSUPPORT':
+                    return { ...state, supported: false, supports: state.supports - 1 }
+                default:
+                    return state
+            }
+        },
+        {
+            supports: note.supports.length,
+            supported: note.supports.some(
+                support => support.userId === loggedInUserId && support.noteId === note.id
+            )
+        }
+    )
+
+    const { mutateAsync: onSupportNote, isPending } = useSupportNote(note.id, {
+        onSuccess: () => {
+            dispatch({ type: supportState.supported ? 'UNSUPPORT' : 'SUPPORT' })
+        },
+        onError: (error) => {
+            console.error('Error toggling support', error)
+            toast({
+                title: 'Error',
+                description: 'An error occurred while toggling support, try again.',
+                variant: 'destructive'
+            })
+        }
+    })
+
+    const handleSupport = async (e: React.MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation()
+        try {
+            await onSupportNote()
+        } catch (error) {
+            console.error('Error toggling support', error)
+        }
+    }
+
+    return { handleSupport, supportState, isPending }
+}

--- a/src/app/(private)/(routes)/(member)/dashboard/components/public-notes-content.tsx
+++ b/src/app/(private)/(routes)/(member)/dashboard/components/public-notes-content.tsx
@@ -8,7 +8,10 @@ export const PublicNotesContent = async () => {
   const notes = await prismadb.note.findMany({
     where: { isPublic: true },
     orderBy: { createdAt: 'desc' },
-    take: 10
+    take: 10,
+    include: {
+      supports: true
+    }
   })
 
   return (

--- a/src/app/(private)/(routes)/(member)/dashboard/components/timeline-notes-content.tsx
+++ b/src/app/(private)/(routes)/(member)/dashboard/components/timeline-notes-content.tsx
@@ -6,6 +6,8 @@ import { Modal } from '@/components/ui/modal'
 import Link from 'next/link'
 import { useState } from 'react'
 import { format } from 'date-fns'
+import NoteSupports from './note-supports'
+import { type ExtendedNote } from '@/lib/types'
 
 type TextNode = {
   type: 'text'
@@ -27,6 +29,8 @@ type TimelineNotesContentProps = {
   content?: string | null
   noteId: string
   updatedAt?: Date
+  note: ExtendedNote
+  loggedInUserId: string
 }
 
 function getFirstParagraphWithText(content: Content): string | null {
@@ -47,10 +51,11 @@ function getFirstParagraphWithText(content: Content): string | null {
 const TimelineNotesContent = ({
   content,
   noteId,
-  updatedAt
+  updatedAt,
+  note,
+  loggedInUserId
 }: TimelineNotesContentProps) => {
   const [isOpen, setIsOpen] = useState(false)
-
   let parsedContent: Content | null = null
   try {
     parsedContent = content ? JSON.parse(content) : null
@@ -79,17 +84,18 @@ const TimelineNotesContent = ({
         <p className="line-clamp-1 truncate text-left my-2 text-muted-foreground">
           {description}
         </p>
-        <div className="flex flex-col justify-center">
+        <div className="flex justify-between gap-2">
           <Button
             onClick={() => {
               setIsOpen(prev => !prev)
             }}
-            className="gap-1"
+            className="gap-1 w-full"
             variant="ghost"
           >
             Preview note
             <Icons.caretSort className="h-4 w-4" />
           </Button>
+          <NoteSupports note={note} loggedInUserId={loggedInUserId} />
         </div>
       </div>
       <Modal

--- a/src/app/(private)/(routes)/(member)/dashboard/components/timeline-notes.tsx
+++ b/src/app/(private)/(routes)/(member)/dashboard/components/timeline-notes.tsx
@@ -1,22 +1,23 @@
 import avatarImg from '@/assets/avatar.png'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import prismadb from '@/lib/prismadb'
-import { type Note } from '@prisma/client'
+import { type ExtendedNote } from '@/lib/types'
 import { format } from 'date-fns'
 import Image from 'next/image'
 import TimelineNotesContent from './timeline-notes-content'
+import { currentUser } from '@clerk/nextjs/server'
 
 type TimelineNotesProps = {
-  note: Note
+  note: ExtendedNote
   lastNote: boolean
 }
 export const TimelineNotes = async ({ note, lastNote }: TimelineNotesProps) => {
+  const user = await currentUser()
   const userProps = await prismadb.user.findUnique({
     where: {
       id: note.userId
     }
   })
-
   return (
     <div className="flex flex-col">
       <div className="flex items-center relative">
@@ -46,6 +47,8 @@ export const TimelineNotes = async ({ note, lastNote }: TimelineNotesProps) => {
         content={note.content}
         noteId={note.id}
         updatedAt={note.updatedAt}
+        note={note}
+        loggedInUserId={user?.id || ''}
       />
     </div>
   )

--- a/src/app/api/note/[noteId]/supports/route.ts
+++ b/src/app/api/note/[noteId]/supports/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server"
+import { auth } from "@clerk/nextjs/server"
+import prismadb from "@/lib/prismadb"
+
+export async function PATCH(
+    req: NextRequest,
+    { params }: { params: { noteId: string } }
+) {
+    try {
+        const { userId } = auth()
+        const { noteId } = params
+
+        if (!userId) return new NextResponse('Unauthenticated', { status: 401 })
+
+        if (!noteId) return new NextResponse('Note ID is required', { status: 400 })
+
+        const note = await prismadb.note.findFirst({
+            where: {
+                id: noteId
+            }
+        })
+
+        if (!note) return new NextResponse('Note not found', { status: 404 })
+
+        const support = await prismadb.noteSupport.findFirst({
+            where: {
+                userId,
+                noteId
+            }
+        })
+
+        if (!support) {
+            await prismadb.noteSupport.create({
+                data: {
+                    userId,
+                    noteId
+                }
+            })
+        } else {
+            await prismadb.noteSupport.delete({
+                where: {
+                    userId_noteId: {
+                        userId,
+                        noteId
+                    }
+                }
+            })
+        }
+        return new NextResponse('Support toggled', { status: 200 })
+    } catch (error) {
+        console.log('[NOTE_SUPPORT_ERROR]', error)
+        return new NextResponse('Internal Server Error', { status: 500 })
+    }
+}

--- a/src/hooks/note/use-note.ts
+++ b/src/hooks/note/use-note.ts
@@ -36,7 +36,19 @@ export const useNote = () => {
       ...options
     })
 
+  const useSupportNote = (
+    noteId: string,
+    options?: UseMutationOptions<AxiosResponse<void>, AxiosError>
+  ) =>
+    useMutation({
+      mutationFn: async () => {
+        return await api.patch(`/api/note/${noteId}/supports`)
+      },
+      ...options
+    })
+
   return {
+    useSupportNote,
     useCreateNewNote,
     useSaveChangesNote,
     useDeleteNote

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,7 +5,9 @@ import {
   type Like,
   type Post,
   type User,
-  type Video
+  type Video,
+  type Note,
+  type NoteSupport
 } from '@prisma/client'
 
 export type MenuItemProps = {
@@ -41,6 +43,10 @@ export enum Positions {
   AMBASSADOR = 'Ambassador',
   ADMIN = 'Admin'
 }
+
+export type ExtendedNote = Note & {
+  supports: NoteSupport[]
+} 
 
 export type ExtendedPost = Post & {
   category: Category


### PR DESCRIPTION
# Context

Today, @yuripramos  announced that the BASE Discord CodeUp channel would be closing, and that CodeUp would be run exclusively by the Borderless Community. While talking to @itspablomontes, he mentioned he would miss the "rocket" emoji reactions that mentees always leave on Discord messages, as it provides a certain motivation to keep going. This gave me the idea to integrate this functionality into the Borderless Community CodeUp.

I based this on the implementation of likes on posts, since it would be a very similar functionality. With this approach, I believe I was able to follow the codebase's coding patterns well, as the final code turned out very similar;

Since this is my first contribution, I focused on keeping it simple, but I'm also considering the possibility of implementing the visualization of who "supported" that CodeUp note, just like it works on Discord.

# Done

## Database & API:
  - Added NoteSupport model to track user support for notes (many-to-many relationship)
  - Implemented PATCH endpoint /api/note/[noteId]/supports to toggle support status

##  Frontend Components:
  - NoteSupports Component: Interactive UI with rocket icon and support counter
  - Enhanced Timeline: Integrated support functionality into note timeline views
  - Real-time Updates: Optimistic UI updates with proper error handling

## Developer Experience:
  - New useNoteSupports hook for state management
  - New useSupportNote hook for API mutations
  - Extended Note type to include support data (ExtendedNote)
  

## Mobile   
|   |   |
|----------|----------|
| <img width="427" height="924" alt="image" src="https://github.com/user-attachments/assets/3399819e-5063-4f65-85fe-8b7d0ec79b06" /> | <img width="424" height="920" alt="image" src="https://github.com/user-attachments/assets/fea90482-a493-4e45-a9a7-ae5aee16bf8e" /> |

## Desktop
|  |  |
|----------|----------|
| <img width="618" height="517" alt="image" src="https://github.com/user-attachments/assets/3fb79500-30e4-48d6-a4b8-8c65027eef76" /> | <img width="629" height="492" alt="image" src="https://github.com/user-attachments/assets/c779dcee-ecc8-48c1-a2e0-3cb912064076" /> |


  