### PR TITLE
Add text highlighting to current mentoring video

### DIFF
--- a/src/app/(private)/(routes)/(member)/mentorship/[videoId]/components/mentorship-tab/index.tsx
+++ b/src/app/(private)/(routes)/(member)/mentorship/[videoId]/components/mentorship-tab/index.tsx
@@ -159,7 +159,7 @@ const MentorshipTab = ({ videoProps, moduleVideos }: MentorshipTabProps) => {
                     </span>
                   </div>
 
-                  <div className="flex flex-col">
+                  <div className="flex flex-col gap-0.5">
                     {videos.map((video, index) => {
                       const isVideoWatched = videosAlreadyWatched.some(
                         item => item === video.id
@@ -174,7 +174,10 @@ const MentorshipTab = ({ videoProps, moduleVideos }: MentorshipTabProps) => {
                             <Tooltip>
                               <TooltipTrigger className="flex w-full">
                                 <Link
-                                  className="flex p-2 w-full items-center justify-between gap-6 cursor-pointer rounded transition-colors hover:bg-muted text-success-light hover:text-success-light"
+                                  className={cn(
+                                    'flex p-2 w-full items-center justify-between gap-6 cursor-pointer rounded transition-colors hover:bg-muted text-success-light hover:text-success-light',
+                                    videoProps.id === video.id && 'bg-muted'
+                                  )}
                                   href={`${appRoutes.mentorship}/${video.id}`}
                                 >
                                   <div className="flex flex-1 items-center gap-3 overflow-hidden">


### PR DESCRIPTION
## Context:
- While browsing and watching some mentoring videos, I found myself getting lost in the video I was watching quite easily. So, I thought adding some kind of text highlighting would be a good idea.

## Preview:
https://github.com/user-attachments/assets/a36ff703-8217-4be8-8344-c9fe4f723e3e

## Problem
> hard to figure out which class you're currently watching

https://github.com/user-attachments/assets/498d853f-96de-4e4d-b10a-68f155cb7d87
