### PR TITLE
fix: when open a note always initialize the state with data from db, …

### DIFF
--- a/src/app/(private)/(routes)/(member)/code-up/[noteId]/components/note-content.tsx
+++ b/src/app/(private)/(routes)/(member)/code-up/[noteId]/components/note-content.tsx
@@ -2,7 +2,7 @@
 import NoteEditor from '@/components/editor/editor'
 import { useNoteStore } from '@/hooks/note/use-note-store'
 import { type Note } from '@prisma/client'
-import { useRef, useState, type ElementRef } from 'react'
+import { useRef, useState, useEffect, type ElementRef } from 'react'
 import TextareaAutosize from 'react-textarea-autosize'
 
 type NoteContentProps = {
@@ -14,10 +14,15 @@ export const NoteContent = ({
   note,
   isPublicView = false
 }: NoteContentProps) => {
-  const { title, onChangeContent, onChangeTitle } = useNoteStore()
+  const { title, onChangeContent, onChangeTitle, initializeNote } =
+    useNoteStore()
 
   const inputRef = useRef<ElementRef<'textarea'>>(null)
   const [isEditingTitle, setIsEditingTitle] = useState(false)
+
+  useEffect(() => {
+    initializeNote(note.title ?? '', note.content ?? '')
+  }, [note.id, note.title, note.content, initializeNote])
 
   const enableInput = () => {
     setIsEditingTitle(true)

--- a/src/hooks/note/use-note-store.ts
+++ b/src/hooks/note/use-note-store.ts
@@ -8,15 +8,19 @@ type State = {
 type Actions = {
   onChangeContent: (content: string) => void
   onChangeTitle: (title: string) => void
+  initializeNote: (title: string, content?: string) => void
 }
 
 export const useNoteStore = create<State & Actions>(set => ({
-  editorContent: undefined,
+  content: undefined,
   title: undefined,
   onChangeContent: content => {
     set({ content })
   },
   onChangeTitle: title => {
     set({ title })
+  },
+  initializeNote: (title: string, content?: string) => {
+    set({ title, content })
   }
 }))


### PR DESCRIPTION
…avoiding state override


https://www.loom.com/share/d109ef1537d34255bce58a0d57d68924